### PR TITLE
Move sequence and title to top of YAML blocks and use title case.

### DIFF
--- a/docs/_mitigations/mi-1.md
+++ b/docs/_mitigations/mi-1.md
@@ -1,12 +1,12 @@
 ---
+sequence: 1
+title: Data Leakage Prevention And Detection
 layout: mitigation
 doc-status: Draft
-sequence: 1
 type:
   - Detective
 mitigates:
   - ri-1
-title: Data Leakage Prevention and Detection
 ---
 
 #### Preventing Leakage of Session Data

--- a/docs/_mitigations/mi-10.md
+++ b/docs/_mitigations/mi-10.md
@@ -1,14 +1,14 @@
 ---
+sequence: 10
+title: Model Version Pinning
 layout: mitigation
 doc-status: Draft
-sequence: 10
 type:
   - Preventative
 mitigates:
   - ri-5
   - ri-6
   - ri-11
-title: Version (pinning) of the foundational model
 ---
 
 #### Supplier Controls:

--- a/docs/_mitigations/mi-11.md
+++ b/docs/_mitigations/mi-11.md
@@ -1,14 +1,14 @@
 ---
+sequence: 11
+title: Human Feedback Loop
 layout: mitigation
 doc-status: Draft
-sequence: 11
 type:
   - Detective
 mitigates:
   - ri-5
   - ri-6
   - ri-11
-title: Human feedback loop
 --- 
 
 #### Human Feedback Loop

--- a/docs/_mitigations/mi-12.md
+++ b/docs/_mitigations/mi-12.md
@@ -1,12 +1,12 @@
 ---
+sequence: 12
+title: Role-Based Data Access
 layout: mitigation
 doc-status: Pre-Draft
-sequence: 12
 type:
  - Preventative
 mitigates:
  - ri-9
-title: Role-based data access 
 ---
 
 - Ensure data provided by Confluence is aligned with the end-user role.

--- a/docs/_mitigations/mi-13.md
+++ b/docs/_mitigations/mi-13.md
@@ -1,12 +1,12 @@
 ---
+sequence: 13
+title: Provide Citations
 layout: mitigation
 doc-status: Pre-Draft
-sequence: 13
 type:
  - Detective
 mitigates:
  - ri-12
-title: Provide citations
 ---
 
 - Provide citations / linkage to the source data in Confluence

--- a/docs/_mitigations/mi-14.md
+++ b/docs/_mitigations/mi-14.md
@@ -1,12 +1,12 @@
 ---
+sequence: 14
+title: Encrypt Data at Rest
 layout: mitigation
 doc-status: Draft
-sequence: 14
 type:
- - Prevantative
+ - Preventative
 mitigates:
  - ri-12
-title: Encrypt data at rest
 ---
 
 Encrypting data at rest involves converting stored information into a secure format using encryption algorithms, making it inaccessible without the proper decryption key. This process protects sensitive data from unauthorized access or breaches, even if the storage medium is compromised. It is considered standard practice, with many tools and organizations turning this feature on by default across their IT estate and third-party tools.

--- a/docs/_mitigations/mi-15.md
+++ b/docs/_mitigations/mi-15.md
@@ -1,12 +1,12 @@
 ---
+sequence: 15
+title: Llm-As-A-Judge
 layout: mitigation
 doc-status: Draft
-sequence: 15
 type:
  - Detective
 mitigates:
  - ri-1
-title: LLM-as-a-Judge
 ---
 
 Testing (evaluating model responses against a set of test cases) and monitoring (continuous evaluation in production) are vital elements in the process of the development and continued deployment of an LLM System, they ensure that your system is functioning properly and that your changes to the system bring a positive improvement, and more. 

--- a/docs/_mitigations/mi-16.md
+++ b/docs/_mitigations/mi-16.md
@@ -1,12 +1,12 @@
 ---
+sequence: 16
+title: Preserving Access Controls in the Ingested Data
 layout: mitigation
 doc-status: Draft
-sequence: 16
 type:
  - Detective
 mitigates:
  - ri-3
-title: Preserving access controls in the ingested data
 ---
 
 When ingesting data to be queried using RAG architecture, the source may have defined different access levels boundaries that are lost in the destination vector storage.

--- a/docs/_mitigations/mi-17.md
+++ b/docs/_mitigations/mi-17.md
@@ -1,12 +1,12 @@
 ---
+sequence: 17
+title: Ai Firewall
 layout: mitigation
 doc-status: Pre-Draft
-sequence: 17
 type:
  - Preventative
 mitigates:
  - ri-10
-title: AI firewall
 ---
 
 An AI firewall would inspect and block user prompts when it detects it may lead to data leakage, making the system unstable, or exahusting resources (number of tokens).

--- a/docs/_mitigations/mi-2.md
+++ b/docs/_mitigations/mi-2.md
@@ -1,12 +1,12 @@
 ---
+sequence: 2
+title: Data Filtering From Confluence Into The Samples
 layout: mitigation
 doc-status: Draft
-sequence: 2
 type:
   - Preventative
 mitigates:
   - ri-1
-title: Data filtering from Confluence into the samples
 ---
 
 To mitigate the risk of sensitive data leakage and tampering in the vector store, the data filtering control ensures that sensitive information from internal knowledge sources, such as Confluence, is anonymized and/or entirely excluded before being processed by the model. This control aims to limit the exposure of sensitive organizational knowledge when creating embeddings that feed into the vector store, thus reducing the likelihood of confidential information being accessible or manipulated.

--- a/docs/_mitigations/mi-3.md
+++ b/docs/_mitigations/mi-3.md
@@ -1,13 +1,13 @@
 ---
+sequence: 3
+title: User/App/Model Firewalling/Filtering
 layout: mitigation
 doc-status: Draft
-sequence: 3
 type:
   - Preventative
 mitigates:
   - ri-7
   - ri-10
-title: User/app/model firewalling/filtering
 ---
 
 As in any information system component, you can monitor and filter interactions between the model, inputs from the user, queries to RAG databases or other sources of information, and outputs.

--- a/docs/_mitigations/mi-4.md
+++ b/docs/_mitigations/mi-4.md
@@ -1,7 +1,8 @@
 ---
+sequence: 4
+title: System Observability
 layout: mitigation
 doc-status: Draft
-sequence: 4
 type:
   - Detective
 mitigates:
@@ -14,7 +15,6 @@ mitigates:
   - ri-8
   - ri-10
   - ri-13
-title: System observability
 ---
 
 #### What to log/monitor

--- a/docs/_mitigations/mi-5.md
+++ b/docs/_mitigations/mi-5.md
@@ -1,7 +1,8 @@
 ---
+sequence: 5
+title: System Acceptance Testing
 layout: mitigation
 doc-status: Draft
-sequence: 5
 type:
  - Preventative
 mitigates:
@@ -9,7 +10,6 @@ mitigates:
  - ri-5
  - ri-6
  - ri-12
-title: System acceptance testing
 ---
 
 System Acceptance Testing is the final phase of the software testing process where the complete system is tested against the specified requirements to ensure it meets the criteria for deployment. For non-AI systems, this will involve creating a number of test cases which are executed, with an expectation that when all tests pass the system is guaranteed to meet its requirements. 

--- a/docs/_mitigations/mi-6.md
+++ b/docs/_mitigations/mi-6.md
@@ -1,13 +1,13 @@
 ---
+sequence: 6
+title: Data Quality & Classification/Sensitivity
 layout: mitigation
 doc-status: Pre-Draft
-sequence: 6
 type:
   - Preventative
 mitigates:
   - ri-1
   - ri-2
-title: Data quality & classification/sensitivity
 ---
 
 - Data is classified within the Confluence data store, and filtered prior to ingestion

--- a/docs/_mitigations/mi-7.md
+++ b/docs/_mitigations/mi-7.md
@@ -1,12 +1,12 @@
 ---
+sequence: 7
+title: Legal/Contractual Agreements
 layout: mitigation
 doc-status: Draft
-sequence: 7
 type:
   - Preventative
 mitigates:
   - ri-1
-title: Legal/contractual agreements
 ---
 
 This control is about legal agreements between the SaaS inference provider and the organization. Those legal agreements not only have to exists, but have to be understood by the organization to make sure they comply with all requirements.

--- a/docs/_mitigations/mi-8.md
+++ b/docs/_mitigations/mi-8.md
@@ -1,12 +1,12 @@
 ---
+sequence: 8
+title: QoS/DDoS Prevention
 layout: mitigation
 doc-status: Pre-Draft
-sequence: 8
 type:
  - Preventative
 mitigates:
  - ri-7
-title: QoS/DDoS prevention
 ---
 
 Controls should be in place to ensure single or few users don't starve finite resources and interfere with the availability of AI systems.

--- a/docs/_mitigations/mi-9.md
+++ b/docs/_mitigations/mi-9.md
@@ -1,12 +1,12 @@
 ---
+sequence: 9
+title: Alerting / DoW Spend Alert
 layout: mitigation
 doc-status: Pre-Draft
-sequence: 9
 type:
   - Detective
 mitigates:
   - ri-7
-title: Alerting / DoW spend alert 
 ---
 
 - Add usage limits and alerts

--- a/docs/_risks/ri-1.md
+++ b/docs/_risks/ri-1.md
@@ -1,9 +1,9 @@
 ---
+sequence: 1
+title: Information Leaked To Hosted Model
 layout: risk
 doc-status: Draft
-sequence: 1
 type: RC
-title: Information Leaked to Hosted Model
 external_risks:
   - LLM06
 ---

--- a/docs/_risks/ri-10.md
+++ b/docs/_risks/ri-10.md
@@ -1,9 +1,9 @@
 ---
+sequence: 10
+title: Prompt Injection
 layout: risk
 doc-status: Draft
-sequence: 10
 type: SEC
-title: Prompt injection
 external_risks:
   - LLM01
   - LLM04

--- a/docs/_risks/ri-11.md
+++ b/docs/_risks/ri-11.md
@@ -1,9 +1,9 @@
 ---
+sequence: 11
+title: Lack of Foundation Model Versioning
 layout: risk
 doc-status: Draft
-sequence: 11
 type: OP
-title: Lack of foundation model versioning
 external_risks:
   - LLM09
 

--- a/docs/_risks/ri-14.md
+++ b/docs/_risks/ri-14.md
@@ -1,9 +1,9 @@
 ---
+sequence: 14
+title: Inadequate System Alignment
 layout: risk
 doc-status: Draft
-sequence: 14
 type: OP
-title: Inadequate system alignment
 external_risks:
   - LLM07
 ---

--- a/docs/_risks/ri-16.md
+++ b/docs/_risks/ri-16.md
@@ -1,10 +1,9 @@
 ---
+sequence: 16
+title: Bias and Discrimination
 layout: risk
 doc-status: Pre-Draft
-sequence: 16
 type: OP
-title: Bias and Discrimination
-
 ---
 
   - AI trained on historical/internet data may embed biases.  

--- a/docs/_risks/ri-17.md
+++ b/docs/_risks/ri-17.md
@@ -1,9 +1,9 @@
 ---
+sequence: 17
+title: Lack of Explainability
 layout: risk
 doc-status: Pre-Draft
-sequence: 17
 type: OP
-title: Lack of Explainabililty
 
 ---
 

--- a/docs/_risks/ri-18.md
+++ b/docs/_risks/ri-18.md
@@ -1,9 +1,9 @@
 ---
+sequence: 18
+title: Model Overreach and Misuse
 layout: risk
 doc-status: Pre-Draft
-sequence: 18
 type: OP
-title: Model Overreach & Misuse 
 
 ---
 

--- a/docs/_risks/ri-19.md
+++ b/docs/_risks/ri-19.md
@@ -1,9 +1,9 @@
 ---
+sequence: 19
+title: Data Quality and Drift
 layout: risk
 doc-status: Pre-Draft
-sequence: 19
 type: OP
-title: Data Quality & Drift
 
 ---
 

--- a/docs/_risks/ri-2.md
+++ b/docs/_risks/ri-2.md
@@ -1,9 +1,9 @@
 ---
+sequence: 2
+title: Unauthorized Access And Data Leaks
 layout: risk
 doc-status: Draft
-sequence: 2
 type: SEC
-title: Unauthorized Access and Data Leaks
 external_risks:
   - LLM06
 ---

--- a/docs/_risks/ri-20.md
+++ b/docs/_risks/ri-20.md
@@ -1,9 +1,9 @@
 ---
+sequence: 20
+title: Reputational Risk
 layout: risk
 doc-status: Pre-Draft
-sequence: 20
 type: OP
-title: Reputational Risk
 
 ---
 

--- a/docs/_risks/ri-22.md
+++ b/docs/_risks/ri-22.md
@@ -1,9 +1,9 @@
 ---
+sequence: 22
+title: Regulatory Compliance and Oversight
 layout: risk
 doc-status: Pre-Draft
-sequence: 22
 type: RC
-title: Regulatory Compliance and Oversight
 
 ---
 

--- a/docs/_risks/ri-23.md
+++ b/docs/_risks/ri-23.md
@@ -1,10 +1,9 @@
 ---
+sequence: 23
+title: Intellectual Property (IP) and Copyright
 layout: risk
 doc-status: Pre-Draft
-sequence: 23
 type: RC
-title: Intellectual Property (IP) and Copyright 
-
 ---
 
 - Generative AI models often train on datasets that may include copyrighted material.  

--- a/docs/_risks/ri-4.md
+++ b/docs/_risks/ri-4.md
@@ -1,9 +1,9 @@
 ---
+sequence: 4
+title: Hallucination and Inaccurate Outputs
 layout: risk
 doc-status: Draft
-sequence: 4
 type: OP
-title: Hallucination and Inaccurate Outputs
 external_risks:
   - LLM08
   - LLM09

--- a/docs/_risks/ri-5.md
+++ b/docs/_risks/ri-5.md
@@ -1,9 +1,9 @@
 ---
+sequence: 5
+title: Instability in Foundation Model Behaviour
 layout: risk
 doc-status: Draft
-sequence: 5
 type: OP
-title: Instability in foundation model behaviour
 external_risks:
   - LLM09
 ---

--- a/docs/_risks/ri-6.md
+++ b/docs/_risks/ri-6.md
@@ -1,9 +1,9 @@
 ---
+sequence: 6
+title: Non-Deterministic Behaviour
 layout: risk
 doc-status: Draft
-sequence: 6
 type: OP
-title: Non-deterministic behaviour
 external_risks:
   - LLM08
   - LLM09

--- a/docs/_risks/ri-7.md
+++ b/docs/_risks/ri-7.md
@@ -1,9 +1,9 @@
 ---
+sequence: 7
+title: Availability of Foundational Model
 layout: risk
 doc-status: Draft
-sequence: 7
 type: OP
-title: Availability of foundational model
 external_risks:
   - LLM04
 ---

--- a/docs/_risks/ri-8.md
+++ b/docs/_risks/ri-8.md
@@ -1,9 +1,9 @@
 ---
+sequence: 8
+title: Tampering With the Foundational Model
 layout: risk
 doc-status: Draft
-sequence: 8
 type: SEC
-title: Tampering with the foundational model
 external_risks:
   - LLM03
   - LLM05

--- a/docs/_risks/ri-9.md
+++ b/docs/_risks/ri-9.md
@@ -1,9 +1,9 @@
 ---
+sequence: 9
+title: Data Poisoning
 layout: risk
 doc-status: Pre-Draft
-sequence: 9
 type: SEC
-title: Data Poisoning
 external_risks:
   - LLM03
   - LLM05


### PR DESCRIPTION
Since the mi-* and ri-* files don't have descriptive filenames, I'm often clicking on them and confirming the title in the IDE. Having them move around was a bit distracting, so I'd like to have them all as the second line of the Markdown files. I have the sequence number as the first line since it's the "primary key".

Since these are titles, applied title case where necessary.