### PR TITLE
Add scripts to download OWASP / NIST LLM risks as Markdown

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,17 @@
+# Download Scripts
+
+These scripts bring in Markdown versions of LLM-related risks from OWASP and NIST to make it easier to enlist a coding assistant (GitHub Copilot, etc.) to help with cross-referencing tasks.
+
+Unless otherwise noted, they are implemented using `bash(1)` and `curl(1)` to (hopefully) make them useful across multiple platforms without needing to worry about language versions and packages.
+
+## dl-owasp-llm-md
+  - Downloads Markdown files from the OWASP repository into the `_refs-markdown/owasp-llm_<year>` directory.
+  - Defaults to 2025 by default. Pass `2024` if you want a copy of that instead.
+  - Usage: `./dl-owasp-llm-md [year]`
+
+## dl_nist-ai-600-1-md`
+   - Downloads the (presumably-latest) `NIST.AI.600-1.md` file from the (unofficial) Cloud Security Alliance GitHub repository.
+   - Saves the file to the `_refs-markdown/nist-ai-600_<year>` directory.
+   - Usage: `./dl_nist-ai-600-1-md`
+
+

--- a/scripts/dl_nist-ai-600-1
+++ b/scripts/dl_nist-ai-600-1
@@ -1,0 +1,29 @@
+#!/bin/bash -eu
+
+SCRIPT_DIR=$(dirname "$0")
+
+# This script downloads the NIST.AI.600-1.md file from the specified GitHub repository
+# using curl and saves it to the appropriate directory.
+# It is not clear that the repo maintainer will keep these up to date,
+# so caveat emptor.
+
+# Message for the user
+echo "The official PDF file is available at:"
+echo "  https://doi.org/10.6028/NIST.AI.600-1"
+echo "Please check that the Markdown is up to date with the PDF!"
+
+# Update this if the Markdown file is updated in the future.
+YEAR=2024
+RAW_URL="https://raw.githubusercontent.com/CloudSecurityAlliance-DataSets/dataset-public-laws-regulations-standards/main/organizations/NIST/NIST.AI.600-1/NIST.AI.600-1.md"
+OUTPUT_DIR="${SCRIPT_DIR}/../_refs-markdown/nist-ai-600-1_$YEAR"
+OUTPUT_FILE="NIST.AI.600-1.md"
+
+# Create output directory if it doesn't exist
+mkdir -p "$OUTPUT_DIR"
+
+# Download the file
+echo "Downloading NIST.AI.600-1.md..."
+curl -s "$RAW_URL" -o "$OUTPUT_DIR/$OUTPUT_FILE"
+
+# Confirm completion
+echo "Download complete. File saved to $OUTPUT_DIR/$OUTPUT_FILE"

--- a/scripts/dl_owasp-llm-md
+++ b/scripts/dl_owasp-llm-md
@@ -1,0 +1,60 @@
+#!/bin/bash -eu
+
+SCRIPT_DIR=$(dirname "$0")
+
+# This script downloads all .md files from an OWASP GitHub repository directory
+# using the GitHub API and curl
+
+# Define variables
+REPO_OWNER="OWASP"
+REPO_NAME="www-project-top-10-for-large-language-model-applications"
+BRANCH="main"
+
+# Ensure year is provided as a parameter
+if [[ $# -lt 1 ]]; then
+  # Default to 2025 if no argument is provided.
+  echo "No year provided. Defaulting to 2025."
+  YEAR=2025
+else
+  YEAR="$1"
+fi
+
+# Adjust directory based on year
+if [[ "$YEAR" == "2024" ]]; then
+  DIRECTORY="Archive/1_1_vulns"
+elif [[ "$YEAR" == "2025" ]]; then
+  DIRECTORY="2_0_vulns"
+else
+  echo "Unsupported year: $YEAR"
+  exit 1
+fi
+
+OUTPUT_DIR="${SCRIPT_DIR}/../_refs-markdown/owasp-llm_$YEAR"
+
+# Create output directory if it doesn't exist
+mkdir -p "$OUTPUT_DIR"
+
+# Get the file list using GitHub API
+echo "Fetching file list from GitHub API for year $YEAR..."
+FILE_LIST=$(curl -s "https://api.github.com/repos/$REPO_OWNER/$REPO_NAME/contents/$DIRECTORY?ref=$BRANCH" |
+            sed -n 's/.*"path": "\(.*\.md\)".*/\1/p')
+
+# Download each markdown file
+echo "Downloading markdown files..."
+IFS=$'\n' # Set Internal Field Separator to handle special characters in file paths
+echo "$FILE_LIST" | while read -r FILE_PATH; do
+    # Extract the filename
+    FILENAME=$(basename "$FILE_PATH")
+    
+    # Define the raw URL for the file
+    RAW_URL="https://raw.githubusercontent.com/$REPO_OWNER/$REPO_NAME/$BRANCH/$FILE_PATH"
+    
+    # Download the file
+    echo "Downloading $FILENAME..."
+    curl -s "$RAW_URL" -o "$OUTPUT_DIR/$FILENAME"
+    
+    # Add a small delay to avoid rate limiting
+    sleep 0.5
+done
+
+echo "Done! All .md files for year $YEAR have been downloaded to $OUTPUT_DIR/"


### PR DESCRIPTION
Download Markdown files into sandbox to use as context for AI Coding Assistants to help with cross referencing.