### PR TITLE
v1 release - Working Group Approval

### DIFF
--- a/docs/_mitigations/mi-10_ai-model-version-pinning.md
+++ b/docs/_mitigations/mi-10_ai-model-version-pinning.md
@@ -2,7 +2,7 @@
 sequence: 10
 title: AI Model Version Pinning
 layout: mitigation
-doc-status: Draft
+doc-status: Approved-Specification
 type: PREV
 iso-42001_references:
   - A-6-2-3  # ISO 42001: Documentation of AI system design and development

--- a/docs/_mitigations/mi-11_human-feedback-loop-for-ai-systems.md
+++ b/docs/_mitigations/mi-11_human-feedback-loop-for-ai-systems.md
@@ -2,7 +2,7 @@
 sequence: 11
 title: Human Feedback Loop for AI Systems
 layout: mitigation
-doc-status: Draft
+doc-status: Approved-Specification
 type: DET
 iso-42001_references:
   - A-6-2-6  # ISO 42001: AI system operation and monitoring

--- a/docs/_mitigations/mi-12_role-based-access-control-for-ai-data.md
+++ b/docs/_mitigations/mi-12_role-based-access-control-for-ai-data.md
@@ -2,7 +2,7 @@
 sequence: 12
 title: Role-Based Access Control for AI Data
 layout: mitigation
-doc-status: Draft
+doc-status: Approved-Specification
 type: PREV
 iso-42001_references:
   - A-3-2  # ISO 42001: AI roles and responsibilities

--- a/docs/_mitigations/mi-13_providing-citations-and-source-traceability-for-ai-generated-information.md
+++ b/docs/_mitigations/mi-13_providing-citations-and-source-traceability-for-ai-generated-information.md
@@ -2,7 +2,7 @@
 sequence: 13
 title: Providing Citations and Source Traceability for AI-Generated Information
 layout: mitigation
-doc-status: Draft
+doc-status: Approved-Specification
 type: DET
 iso-42001_references:
   - A-8-2    # ISO 42001: System documentation and information for users

--- a/docs/_mitigations/mi-14_encryption-of-ai-data-at-rest.md
+++ b/docs/_mitigations/mi-14_encryption-of-ai-data-at-rest.md
@@ -2,7 +2,7 @@
 sequence: 14
 title: Encryption of AI Data at Rest
 layout: mitigation
-doc-status: Draft
+doc-status: Approved-Specification
 type: PREV
 iso-42001_references:
   - A-7-2  # ISO 42001: Data for development and enhancement of AI system

--- a/docs/_mitigations/mi-15_using-large-language-models-for-automated-evaluation-llm-as-a-judge-.md
+++ b/docs/_mitigations/mi-15_using-large-language-models-for-automated-evaluation-llm-as-a-judge-.md
@@ -2,7 +2,7 @@
 sequence: 15
 title: Using Large Language Models for Automated Evaluation (LLM-as-a-Judge)
 layout: mitigation
-doc-status: Draft
+doc-status: Approved-Specification
 type: DET
 iso-42001_references:
   - A-6-2-4  # ISO 42001: AI system verification and validation

--- a/docs/_mitigations/mi-16_preserving-source-data-access-controls-in-ai-systems.md
+++ b/docs/_mitigations/mi-16_preserving-source-data-access-controls-in-ai-systems.md
@@ -2,7 +2,7 @@
 sequence: 16
 title: Preserving Source Data Access Controls in AI Systems
 layout: mitigation
-doc-status: Draft
+doc-status: Approved-Specification
 type: DET
 iso-42001_references:
   - A-7-2  # ISO 42001: Data for development and enhancement of AI system

--- a/docs/_mitigations/mi-17_ai-firewall-implementation-and-management.md
+++ b/docs/_mitigations/mi-17_ai-firewall-implementation-and-management.md
@@ -2,7 +2,7 @@
 sequence: 17
 title: AI Firewall Implementation and Management
 layout: mitigation
-doc-status: Draft
+doc-status: Approved-Specification
 type: PREV
 iso-42001_references:
   - A-6-1-3  # ISO 42001: Processes for responsible AI system design and development

--- a/docs/_mitigations/mi-1_ai-data-leakage-prevention-and-detection.md
+++ b/docs/_mitigations/mi-1_ai-data-leakage-prevention-and-detection.md
@@ -2,7 +2,7 @@
 sequence: 1
 title: AI Data Leakage Prevention and Detection
 layout: mitigation
-doc-status: Draft
+doc-status: Approved-Specification
 type: DET
 iso-42001_references:
   - A-7-2    # ISO 42001: Data for development and enhancement of AI system

--- a/docs/_mitigations/mi-2_data-filtering-from-external-knowledge-bases.md
+++ b/docs/_mitigations/mi-2_data-filtering-from-external-knowledge-bases.md
@@ -2,7 +2,7 @@
 sequence: 2
 title: Data Filtering From External Knowledge Bases
 layout: mitigation
-doc-status: Draft
+doc-status: Approved-Specification
 type: PREV
 iso-42001_references:
   - A-7-2  # ISO 42001: Data for development and enhancement of AI system

--- a/docs/_mitigations/mi-3_user-app-model-firewalling-filtering.md
+++ b/docs/_mitigations/mi-3_user-app-model-firewalling-filtering.md
@@ -2,7 +2,7 @@
 sequence: 3
 title: User/App/Model Firewalling/Filtering
 layout: mitigation
-doc-status: Draft
+doc-status: Approved-Specification
 type: PREV
 iso-42001_references:
   - A-6-1-3  # ISO 42001: Processes for responsible AI system design and development

--- a/docs/_mitigations/mi-4_ai-system-observability.md
+++ b/docs/_mitigations/mi-4_ai-system-observability.md
@@ -2,7 +2,7 @@
 sequence: 4
 title: AI System Observability
 layout: mitigation
-doc-status: Draft
+doc-status: Approved-Specification
 type: DET
 iso-42001_references:
   - A-6-2-6  # ISO 42001: AI system operation and monitoring

--- a/docs/_mitigations/mi-5_system-acceptance-testing.md
+++ b/docs/_mitigations/mi-5_system-acceptance-testing.md
@@ -2,7 +2,7 @@
 sequence: 5
 title: System Acceptance Testing
 layout: mitigation
-doc-status: Draft
+doc-status: Approved-Specification
 type: PREV
 iso-42001_references:
   - A-6-2-4  # ISO 42001: AI system verification and validation

--- a/docs/_mitigations/mi-6_data-quality-classification-sensitivity.md
+++ b/docs/_mitigations/mi-6_data-quality-classification-sensitivity.md
@@ -2,7 +2,7 @@
 sequence: 6
 title: Data Quality & Classification/Sensitivity
 layout: mitigation
-doc-status: Draft
+doc-status: Approved-Specification
 type: PREV
 iso-42001_references:
   - A-7-4  # ISO 42001: Quality of data for AI systems

--- a/docs/_mitigations/mi-7_legal-and-contractual-frameworks-for-ai-systems.md
+++ b/docs/_mitigations/mi-7_legal-and-contractual-frameworks-for-ai-systems.md
@@ -2,7 +2,7 @@
 sequence: 7
 title: Legal and Contractual Frameworks for AI Systems
 layout: mitigation
-doc-status: Draft
+doc-status: Approved-Specification
 type: PREV
 iso-42001_references:
   - A-2-3   # ISO 42001: Alignment with other organizational policies

--- a/docs/_mitigations/mi-8_quality-of-service-qos-and-ddos-prevention-for-ai-systems.md
+++ b/docs/_mitigations/mi-8_quality-of-service-qos-and-ddos-prevention-for-ai-systems.md
@@ -2,7 +2,7 @@
 sequence: 8
 title: Quality of Service (QoS) and DDoS Prevention for AI Systems
 layout: mitigation
-doc-status: Draft
+doc-status: Approved-Specification
 type: PREV
 iso-42001_references:
   - A-6-2-6  # ISO 42001: AI system operation and monitoring

--- a/docs/_mitigations/mi-9_ai-system-alerting-and-denial-of-wallet-dow-spend-monitoring.md
+++ b/docs/_mitigations/mi-9_ai-system-alerting-and-denial-of-wallet-dow-spend-monitoring.md
@@ -2,7 +2,7 @@
 sequence: 9
 title: AI System Alerting and Denial of Wallet (DoW) / Spend Monitoring
 layout: mitigation
-doc-status: Draft
+doc-status: Approved-Specification
 type: DET
 iso-42001_references:
   - A-6-2-6  # ISO 42001: AI system operation and monitoring

--- a/docs/_risks/ri-10_prompt-injection.md
+++ b/docs/_risks/ri-10_prompt-injection.md
@@ -2,7 +2,7 @@
 sequence: 10
 title: Prompt Injection
 layout: risk
-doc-status: Draft
+doc-status: Approved-Specification
 type: SEC
 owasp-llm_references:
   - llm01-2025  # LLM01:2025 Prompt Injection

--- a/docs/_risks/ri-14_inadequate-system-alignment.md
+++ b/docs/_risks/ri-14_inadequate-system-alignment.md
@@ -2,7 +2,7 @@
 sequence: 14
 title: Inadequate System Alignment
 layout: risk
-doc-status: Draft
+doc-status: Approved-Specification
 type: OP
 ffiec-itbooklets_references:
   - dam-3  # DAM: III Risk Management of Development, Acquisition, and Maintenance

--- a/docs/_risks/ri-16_bias-and-discrimination.md
+++ b/docs/_risks/ri-16_bias-and-discrimination.md
@@ -2,7 +2,7 @@
 sequence: 16
 title: Bias and Discrimination
 layout: risk
-doc-status: Draft
+doc-status: Approved-Specification
 type: OP
 nist-ai-600-1_references:
   - 2-6  # 2.6. Harmful Bias and Homogenization

--- a/docs/_risks/ri-17_lack-of-explainability.md
+++ b/docs/_risks/ri-17_lack-of-explainability.md
@@ -2,7 +2,7 @@
 sequence: 17
 title: Lack of Explainability
 layout: risk
-doc-status: Draft
+doc-status: Approved-Specification
 type: OP
 owasp-llm_references:
   - llm05-2025  # LLM05:2025 Improper Output Handling

--- a/docs/_risks/ri-18_model-overreach-expanded-use.md
+++ b/docs/_risks/ri-18_model-overreach-expanded-use.md
@@ -2,7 +2,7 @@
 sequence: 18
 title: Model Overreach / Expanded Use
 layout: risk
-doc-status: Draft
+doc-status: Approved-Specification
 type: OP
 owasp-llm_references:
   - llm06-2025  # LLM06:2025 Excessive Agency

--- a/docs/_risks/ri-19_data-quality-and-drift.md
+++ b/docs/_risks/ri-19_data-quality-and-drift.md
@@ -2,7 +2,7 @@
 sequence: 19
 title: Data Quality and Drift
 layout: risk
-doc-status: Draft
+doc-status: Approved-Specification
 type: OP
 nist-ai-600-1_references:
   - 2-8  # 2.8. Information Integrity

--- a/docs/_risks/ri-1_information-leaked-to-hosted-model.md
+++ b/docs/_risks/ri-1_information-leaked-to-hosted-model.md
@@ -2,7 +2,7 @@
 sequence: 1
 title: Information Leaked To Hosted Model
 layout: risk
-doc-status: Draft
+doc-status: Approved-Specification
 type: RC
 owasp-llm_references:
   - llm06-2025  # LLM06:2025 Excessive Agency

--- a/docs/_risks/ri-20_reputational-risk.md
+++ b/docs/_risks/ri-20_reputational-risk.md
@@ -2,7 +2,7 @@
 sequence: 20
 title: Reputational Risk
 layout: risk
-doc-status: Draft
+doc-status: Approved-Specification
 type: OP
 owasp-llm_references:
   - llm09-2025  # LLM09:2025 Misinformation

--- a/docs/_risks/ri-22_regulatory-compliance-and-oversight.md
+++ b/docs/_risks/ri-22_regulatory-compliance-and-oversight.md
@@ -2,7 +2,7 @@
 sequence: 22
 title: Regulatory Compliance and Oversight
 layout: risk
-doc-status: Draft
+doc-status: Approved-Specification
 type: RC
 nist-ai-600-1_references:
   - 2-9  # 2.9. Information Security

--- a/docs/_risks/ri-23_intellectual-property-ip-and-copyright.md
+++ b/docs/_risks/ri-23_intellectual-property-ip-and-copyright.md
@@ -2,7 +2,7 @@
 sequence: 23
 title: Intellectual Property (IP) and Copyright
 layout: risk
-doc-status: Draft
+doc-status: Approved-Specification
 type: RC
 nist-ai-600-1_references:
   - 2-10  # 2.10. Intellectual Property

--- a/docs/_risks/ri-2_information-leaked-to-vector-store.md
+++ b/docs/_risks/ri-2_information-leaked-to-vector-store.md
@@ -2,7 +2,7 @@
 sequence: 2
 title: Information Leaked to Vector Store
 layout: risk
-doc-status: Draft
+doc-status: Approved-Specification
 type: SEC
 owasp-llm_references:
   - llm06-2025  # LLM06:2025 Excessive Agency

--- a/docs/_risks/ri-4_hallucination-and-inaccurate-outputs.md
+++ b/docs/_risks/ri-4_hallucination-and-inaccurate-outputs.md
@@ -2,7 +2,7 @@
 sequence: 4
 title: Hallucination and Inaccurate Outputs
 layout: risk
-doc-status: Draft
+doc-status: Approved-Specification
 type: OP
 owasp-llm_references:
   - llm09-2025  # LLM09:2025 Misinformation

--- a/docs/_risks/ri-5_foundation-model-versioning.md
+++ b/docs/_risks/ri-5_foundation-model-versioning.md
@@ -2,7 +2,7 @@
 sequence: 5
 title: Foundation Model Versioning
 layout: risk
-doc-status: Draft
+doc-status: Approved-Specification
 type: OP
 related_risks:
   - ri-7  # Availability of Foundational Model

--- a/docs/_risks/ri-6_non-deterministic-behaviour.md
+++ b/docs/_risks/ri-6_non-deterministic-behaviour.md
@@ -2,7 +2,7 @@
 sequence: 6
 title: Non-Deterministic Behaviour
 layout: risk
-doc-status: Draft
+doc-status: Approved-Specification
 type: OP
 owasp-llm_references:
   - llm09-2025  # LLM09:2025 Misinformation

--- a/docs/_risks/ri-7_availability-of-foundational-model.md
+++ b/docs/_risks/ri-7_availability-of-foundational-model.md
@@ -2,7 +2,7 @@
 sequence: 7
 title: Availability of Foundational Model
 layout: risk
-doc-status: Draft
+doc-status: Approved-Specification
 type: OP
 owasp-llm_references:
   - llm10-2025  # LLM10:2025 Unbounded Consumption

--- a/docs/_risks/ri-8_tampering-with-the-foundational-model.md
+++ b/docs/_risks/ri-8_tampering-with-the-foundational-model.md
@@ -2,7 +2,7 @@
 sequence: 8
 title: Tampering With the Foundational Model
 layout: risk
-doc-status: Draft
+doc-status: Approved-Specification
 type: SEC
 owasp-llm_references:
   - llm03-2025  # LLM03:2025 Supply Chain

--- a/docs/_risks/ri-9_data-poisoning.md
+++ b/docs/_risks/ri-9_data-poisoning.md
@@ -2,7 +2,7 @@
 sequence: 9
 title: Data Poisoning
 layout: risk
-doc-status: Draft
+doc-status: Approved-Specification
 type: SEC
 owasp-llm_references:
   - llm03-2025  # LLM03:2025 Supply Chain


### PR DESCRIPTION
I am seeking approval from Working Group members to move all risks / mitigations from `Draft` to `Approved-Specification` status, as per our [Governance Process](https://github.com/finos/ai-governance-framework/blob/main/GOVERNANCE.md).

We have a total of 34 documented risks and mitigations, all in a complete (draft) stage. That's 2,569 lines of text  and 33,827 words. 

We have mappings to seven different external references:

- OWASP LLM Top 10
- OWASP Machine Learning Security Top 10
- FFIEC
- EU AI Act
- ISO42001
- NIST Trustworthy and Responsible AI (NIST AI 600-1)
- NIST Special Publication 800-53

Which far exceeds are earlier goal to map to just NIST and OWASP.

It's time to cut a v1 release ahead of OSFF. Please provide your support via a +1 or thumbs-up