### PR TITLE
add: edit on github links

### DIFF
--- a/docs/_layouts/mitigation.html
+++ b/docs/_layouts/mitigation.html
@@ -14,10 +14,22 @@ layout: default
         </div>
         <div class="mitigation-id mb-2">{% include mitigation-id.html mitigation=page %}</div>
         <div class="container">
-            <div class="d-flex align-items-center">
-                <img src="/2025_AIGovernanceFramework_Icon.png" alt="AI Governance Framework Icon" style="height: 48px;" class="me-3 mb-0">
+            <div class="d-flex align-items-center justify-content-between">
+                <div class="d-flex align-items-center">
+                    <img src="/2025_AIGovernanceFramework_Icon.png" alt="AI Governance Framework Icon" style="height: 48px;" class="me-3 mb-0">
+                    <div>
+                        <h1 class="display-4 mb-0">{{ page.title }}</h1>
+                    </div>
+                </div>
                 <div>
-                    <h1 class="display-4 mb-0">{{ page.title }}</h1>
+                    <a href="https://github.com/finos/ai-governance-framework/edit/main/docs/{{ page.path }}" 
+                       target="_blank" 
+                       class="btn btn-outline-primary btn-sm">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-github me-2" viewBox="0 0 16 16">
+                            <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.012 8.012 0 0 0 16 8c0-4.42-3.58-8-8-8z"/>
+                        </svg>
+                        Edit on GitHub
+                    </a>
                 </div>
             </div>
         </div>

--- a/docs/_layouts/risk.html
+++ b/docs/_layouts/risk.html
@@ -14,10 +14,22 @@ layout: default
         </div>
         <div class="risk-id mb-2">{% include risk-id.html risk=page %}</div>
         <div class="container">
-            <div class="d-flex align-items-center">
-                <img src="/2025_AIGovernanceFramework_Icon.png" alt="AI Governance Framework Icon" style="height: 48px;" class="me-3 mb-0">
+            <div class="d-flex align-items-center justify-content-between">
+                <div class="d-flex align-items-center">
+                    <img src="/2025_AIGovernanceFramework_Icon.png" alt="AI Governance Framework Icon" style="height: 48px;" class="me-3 mb-0">
+                    <div>
+                        <h1 class="display-4 mb-0">{{ page.title }}</h1>
+                    </div>
+                </div>
                 <div>
-                    <h1 class="display-4 mb-0">{{ page.title }}</h1>
+                    <a href="https://github.com/finos/ai-governance-framework/edit/main/docs/{{ page.path }}" 
+                       target="_blank" 
+                       class="btn btn-outline-primary btn-sm">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-github me-2" viewBox="0 0 16 16">
+                            <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.012 8.012 0 0 0 16 8c0-4.42-3.58-8-8-8z"/>
+                        </svg>
+                        Edit on GitHub
+                    </a>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Addresses https://github.com/finos/ai-governance-framework/issues/181

This is what it looks like on the site:
<img width="1362" height="1110" alt="gh-edit-1" src="https://github.com/user-attachments/assets/ed6d309b-ce9e-4732-90a5-08e021ccd97b" />
<img width="1685" height="1051" alt="gh-edit-2" src="https://github.com/user-attachments/assets/751a4b4e-24ac-4b3c-a462-71bea99fd05b" />
