### PR TITLE
Replace hallucination examples with financial-specific ones

### DIFF
--- a/docs/_risks/ri-4_hallucination-and-inaccurate-outputs.md
+++ b/docs/_risks/ri-4_hallucination-and-inaccurate-outputs.md
@@ -48,7 +48,7 @@ Several factors increase the risk of hallucination:
 
 ## Example Financial Services Hallucinations
 
-Below are a few illustrative cases of LLM hallucination tailored to the financial services industry.
+Below are a few illustrative, hypothetical cases of LLM hallucination tailored to the financial services industry.
 
 1. **Fabricated Financial News or Analysis**
    An LLM-powered market analysis tool incorrectly reports that 'Fictional Bank Corp' has missed its quarterly earnings target based on a non-existent press release, causing a temporary dip in its stock price.


### PR DESCRIPTION
The previous examples of AI hallucinations in the risk document were generic. This commit replaces them with examples that are more relevant to the financial services industry, making the framework more applicable to its intended audience.

This addresses the ask in https://github.com/finos/ai-governance-framework/issues/166 