### PR TITLE
Add a single-page HTML for the FINOS AI Governance Framework

### DIFF
--- a/docs/_layouts/index.html
+++ b/docs/_layouts/index.html
@@ -19,7 +19,7 @@ layout: default
             </em>
         </p>
         <div class="mt-3">
-            <a href="/single-page.html" class="btn btn-primary btn-sm" target="_blank" rel="noopener">Show single page</a>
+            <a href="/single-page.html" class="btn btn-primary btn-sm" target="_blank" rel="noopener"><i class="bi bi-printer"></i> Print-ready copy</a>
         </div>
 
         <div class="alert alert-info mt-3 mb-0" role="alert">

--- a/docs/_layouts/index.html
+++ b/docs/_layouts/index.html
@@ -18,11 +18,13 @@ layout: default
             ({{ formatted_date }})
             </em>
         </p>
+        <div class="mt-3">
+            <a href="/single-page.html" class="btn btn-primary btn-sm" target="_blank" rel="noopener">Show single page</a>
+        </div>
 
         <div class="alert alert-info mt-3 mb-0" role="alert">
             <strong>📚 Alert: FINOS will be running a first alpha of the <a href="https://www.finos.org/ai-governance-framework-training">AI Governance Leader Training</a> at <a href="https://events.linuxfoundation.org/open-source-finance-forum-toronto/">OSFF Toronto</a> !</strong> We're almost at capacity so <a href="https://sched.co/2HliQ">register today</a> to be in the first cohort of FINOS AI Governance Leaders learning how to operationalise AIGF, embedding its risk, controls, and assurance concepts into existing governance and risk processes
         </div>
-        
     </div>
 </header>
 

--- a/docs/single-page.html
+++ b/docs/single-page.html
@@ -1,0 +1,65 @@
+---
+layout: default
+title: "Single Page - FINOS AI Governance Framework"
+---
+
+<div class="container py-4">
+  <div class="d-flex justify-content-between align-items-center mb-4">
+    <h1>FINOS AI Governance Framework — Single Page</h1>
+    <div>
+      <a href="/" class="btn btn-outline-secondary btn-sm">Back</a>
+      <button class="btn btn-outline-primary btn-sm" onclick="window.print()">Print / Save as PDF</button>
+    </div>
+  </div>
+
+  <nav class="mb-4">
+    <h5>Contents</h5>
+    <ul>
+      <li><a href="#risks">Risk Catalogue</a>
+        <ul>
+          {% for risk in site.risks %}
+            <li><a href="#{{ risk.id }}">{{ risk.title }}</a></li>
+          {% endfor %}
+        </ul>
+      </li>
+      <li><a href="#mitigations">Mitigation Catalogue</a>
+        <ul>
+          {% for mitigation in site.mitigations %}
+            <li><a href="#{{ mitigation.id }}">{{ mitigation.title }}</a></li>
+          {% endfor %}
+        </ul>
+      </li>
+    </ul>
+  </nav>
+
+  <section id="risks">
+    <h2>Risk Catalogue</h2>
+    {% assign sorted_risks = site.risks | sort: 'sequence' %}
+    {% for risk in sorted_risks %}
+      <article id="{{ risk.id }}" class="mb-4">
+        <h3>{{ risk.title }}</h3>
+        <div class="text-muted mb-2 small">{{ risk.date | date: "%B %d, %Y" }}</div>
+        <div>
+          {{ risk.content }}
+        </div>
+        <hr/>
+      </article>
+    {% endfor %}
+  </section>
+
+  <section id="mitigations" class="mt-5">
+    <h2>Mitigation Catalogue</h2>
+    {% assign sorted_mitigations = site.mitigations | sort: 'sequence' %}
+    {% for mitigation in sorted_mitigations %}
+      <article id="{{ mitigation.id }}" class="mb-4">
+        <h3>{{ mitigation.title }}</h3>
+        <div class="text-muted mb-2 small">{{ mitigation.date | date: "%B %d, %Y" }}</div>
+        <div>
+          {{ mitigation.content }}
+        </div>
+        <hr/>
+      </article>
+    {% endfor %}
+  </section>
+
+</div>

--- a/docs/single-page.html
+++ b/docs/single-page.html
@@ -1,18 +1,24 @@
 ---
 layout: default
-title: "Single Page - FINOS AI Governance Framework"
+title: "FINOS AI Governance Framework"
 ---
 
 <div class="container py-4">
   <div class="d-flex justify-content-between align-items-center mb-4">
-    <h1>FINOS AI Governance Framework — Single Page</h1>
+    <h1>FINOS AI Governance Framework</h1>
     <div>
       <a href="/" class="btn btn-outline-secondary btn-sm">Back</a>
       <button class="btn btn-outline-primary btn-sm" onclick="window.print()">Print / Save as PDF</button>
     </div>
   </div>
 
-  <nav class="mb-4">
+  <div class="mb-4">
+    <p>AI, especially Generative AI, is reshaping financial services, enhancing products, client interactions, and productivity. However, challenges like hallucinations and model unpredictability make safe deployment complex. Rapid advancements require flexible governance.</p>
+    <p>Financial institutions are eager to adopt AI but face regulatory hurdles. Existing frameworks may not address AI's unique risks, necessitating an adaptive governance model for safe and compliant integration.</p>
+    <p>The following framework has been developed by <a href="https://www.finos.org/">FINOS (Fintech Open Source Foundation)</a> members, providing a comprehensive catalogue of risks and associated mitigations.</p>
+  </div>
+
+  <div class="mb-4 toc">
     <h5>Contents</h5>
     <ul>
       <li><a href="#risks">Risk Catalogue</a>
@@ -30,7 +36,7 @@ title: "Single Page - FINOS AI Governance Framework"
         </ul>
       </li>
     </ul>
-  </nav>
+  </div>
 
   <section id="risks">
     <h2>Risk Catalogue</h2>

--- a/docs/style.css
+++ b/docs/style.css
@@ -258,15 +258,21 @@ a:focus {
     outline-offset: 2px;
 }
 
-/* Print styles */
+/* Print styles to make single-page PDF-friendly */
 @media print {
-    .btn, 
-    .collapse-btn,
-    .form-control,
-    .form-select {
+    nav, .btn, .collapse-btn, .form-control, .form-select, .external-link-icon, footer {
         display: none !important;
     }
-    
+    body {
+        color: #000;
+        background: #fff;
+    }
+    h1, h2, h3 {
+        page-break-after: avoid;
+    }
+    article {
+        page-break-inside: avoid;
+    }
     .card {
         border: 1px solid #dee2e6 !important;
         box-shadow: none !important;
@@ -314,7 +320,7 @@ a:focus {
         line-clamp: 3;
         max-height: 4.2em; /* 3 lines * 1.4 line-height */
     }
-    
+
     .col-12 .description-text {
         -webkit-line-clamp: 5;
         line-clamp: 5;
@@ -328,7 +334,7 @@ a:focus {
         line-clamp: 2;
         max-height: 2.8em;
     }
-    
+
     .col-12 .description-text {
         -webkit-line-clamp: 4;
         line-clamp: 4;


### PR DESCRIPTION
Introduce a new single-page HTML that consolidates the risk and mitigation catalogues, enhancing accessibility and usability. Include print-friendly styles for better document handling. A link to this page is added to the main interface.