### PR TITLE
Match catalogue ordering and show AIR IDs on single-page view

### DIFF
--- a/docs/single-page.html
+++ b/docs/single-page.html
@@ -1,6 +1,13 @@
 ---
 layout: default
 title: "FINOS AI Governance Framework"
+risk_order:
+  - OP
+  - SEC
+  - RC
+mitigation_order:
+  - PREV
+  - DET
 ---
 
 <div class="container py-4">
@@ -23,15 +30,37 @@ title: "FINOS AI Governance Framework"
     <ul>
       <li><a href="#risks">Risk Catalogue</a>
         <ul>
-          {% for risk in site.risks %}
-            <li><a href="#{{ risk.id }}">{{ risk.title }}</a></li>
+          {% for order in page.risk_order %}
+            {% assign risk_group = site.risks | group_by: "type" | where: "name", order | first %}
+            {% if risk_group %}
+              <li>
+                <strong>{{ site.risk_classification[risk_group.name] }}</strong>
+                <ul>
+                  {% assign sorted_risks = risk_group.items | sort: "sequence" %}
+                  {% for risk in sorted_risks %}
+                    <li><a href="#{{ risk.id }}">{% include risk-id.html risk=risk %} &mdash; {{ risk.title }}</a></li>
+                  {% endfor %}
+                </ul>
+              </li>
+            {% endif %}
           {% endfor %}
         </ul>
       </li>
       <li><a href="#mitigations">Mitigation Catalogue</a>
         <ul>
-          {% for mitigation in site.mitigations %}
-            <li><a href="#{{ mitigation.id }}">{{ mitigation.title }}</a></li>
+          {% for order in page.mitigation_order %}
+            {% assign mitigation_group = site.mitigations | group_by: "type" | where: "name", order | first %}
+            {% if mitigation_group %}
+              <li>
+                <strong>{{ site.mitigation_classification[mitigation_group.name] }}</strong>
+                <ul>
+                  {% assign sorted_mitigations = mitigation_group.items | sort: "sequence" %}
+                  {% for mitigation in sorted_mitigations %}
+                    <li><a href="#{{ mitigation.id }}">{% include mitigation-id.html mitigation=mitigation %} &mdash; {{ mitigation.title }}</a></li>
+                  {% endfor %}
+                </ul>
+              </li>
+            {% endif %}
           {% endfor %}
         </ul>
       </li>
@@ -40,31 +69,43 @@ title: "FINOS AI Governance Framework"
 
   <section id="risks">
     <h2>Risk Catalogue</h2>
-    {% assign sorted_risks = site.risks | sort: 'sequence' %}
-    {% for risk in sorted_risks %}
-      <article id="{{ risk.id }}" class="mb-4">
-        <h3>{{ risk.title }}</h3>
-        <div class="text-muted mb-2 small">{{ risk.date | date: "%B %d, %Y" }}</div>
-        <div>
-          {{ risk.content }}
-        </div>
-        <hr/>
-      </article>
+    {% for order in page.risk_order %}
+      {% assign risk_group = site.risks | group_by: "type" | where: "name", order | first %}
+      {% if risk_group %}
+        <h3 class="mt-4">{{ site.risk_classification[risk_group.name] }}</h3>
+        {% assign sorted_risks = risk_group.items | sort: "sequence" %}
+        {% for risk in sorted_risks %}
+          <article id="{{ risk.id }}" class="mb-4">
+            <h4>{{ risk.title }}</h4>
+            <div class="text-muted mb-2 small">{% include risk-id.html risk=risk %}</div>
+            <div>
+              {{ risk.content }}
+            </div>
+            <hr/>
+          </article>
+        {% endfor %}
+      {% endif %}
     {% endfor %}
   </section>
 
   <section id="mitigations" class="mt-5">
     <h2>Mitigation Catalogue</h2>
-    {% assign sorted_mitigations = site.mitigations | sort: 'sequence' %}
-    {% for mitigation in sorted_mitigations %}
-      <article id="{{ mitigation.id }}" class="mb-4">
-        <h3>{{ mitigation.title }}</h3>
-        <div class="text-muted mb-2 small">{{ mitigation.date | date: "%B %d, %Y" }}</div>
-        <div>
-          {{ mitigation.content }}
-        </div>
-        <hr/>
-      </article>
+    {% for order in page.mitigation_order %}
+      {% assign mitigation_group = site.mitigations | group_by: "type" | where: "name", order | first %}
+      {% if mitigation_group %}
+        <h3 class="mt-4">{{ site.mitigation_classification[mitigation_group.name] }}</h3>
+        {% assign sorted_mitigations = mitigation_group.items | sort: "sequence" %}
+        {% for mitigation in sorted_mitigations %}
+          <article id="{{ mitigation.id }}" class="mb-4">
+            <h4>{{ mitigation.title }}</h4>
+            <div class="text-muted mb-2 small">{% include mitigation-id.html mitigation=mitigation %}</div>
+            <div>
+              {{ mitigation.content }}
+            </div>
+            <hr/>
+          </article>
+        {% endfor %}
+      {% endif %}
     {% endfor %}
   </section>
 


### PR DESCRIPTION
Closes #288.

## Summary

- Group the single-page risk list by `type` in `OP → SEC → RC` order (matches `docs/_includes/catalogue.html`)
- Group the single-page mitigation list by `type` in `PREV → DET` order (ditto)
- Render each entry's canonical `AIR-{type}-{seq}` reference (via the existing `risk-id.html` / `mitigation-id.html` partials) in place of the previous `risk.date` / `mitigation.date` line, which wasn't meaningful on a printable view
- Add category headings and propagate the grouped ordering + AIR IDs to the in-page table of contents

Ordering and classification labels come from the same `site.risk_classification` / `site.mitigation_classification` config used by the main catalogue, so the two views stay in sync.

## Before / After

### Table of contents & grouping

**Before** — flat list, interleaved categories:

![before – single page TOC](https://raw.githubusercontent.com/finos/ai-governance-framework/pr-assets/288/before_single_page.png)

**After** — grouped by Operational → Security → Regulatory & Compliance, with AIR IDs next to each title:

![after – single page TOC](https://raw.githubusercontent.com/finos/ai-governance-framework/pr-assets/288/after_single_page.png)

### Per-entry header

**Before** — date under the title:

![before – risk entry with date](https://raw.githubusercontent.com/finos/ai-governance-framework/pr-assets/288/before_risk_entry.png)

**After** — canonical `AIR-OP-004` reference under the title, and the section is prefixed with its `Operational` group heading:

![after – risk entry with AIR ID](https://raw.githubusercontent.com/finos/ai-governance-framework/pr-assets/288/after_risk_entry.png)

_(Screenshots are hosted on the companion `pr-assets/288` branch so they don't clutter this PR's diff.)_

## Test plan

- [ ] `cd docs && jekyll serve` and open `http://localhost:4000/single-page.html`
- [ ] Confirm the risk catalogue renders in order Operational → Security → Regulatory & Compliance, and each section's entries are sorted by `sequence`
- [ ] Confirm the mitigation catalogue renders Preventative → Detective, sorted by `sequence`
- [ ] Confirm every entry shows its `AIR-{type}-{###}` reference (not a date) beneath the title
- [ ] Confirm the in-page TOC groups match the body groups, and TOC links still scroll to the right anchors
- [ ] `window.print()` preview still looks sensible for PDF export

🤖 Generated with [Claude Code](https://claude.com/claude-code)