### PR TITLE
Add Canada (CSA / CIRO / OSFI / OPC) regulatory reference data

### DIFF
--- a/docs/_data/canada-regulations.yml
+++ b/docs/_data/canada-regulations.yml
@@ -1,0 +1,363 @@
+# Canada AI & Financial-Sector Regulatory References
+#
+# Schema mirrors eu-ai-act.yml and ffiec-itbooklets.yml:
+#   key:
+#     title: <short, single-line citation>
+#     url: <canonical URL>
+#     issuer: <CSA | CIRO | CSA/CIRO | OSFI | OPC | FCAC | IOSCO | Parliament of Canada>
+#     description: <optional richer context; not rendered by current layouts>
+#
+# Tiers below are expressed via comments only; the schema itself stays flat.
+# Sub-entries (e.g., osfi-e23-p1) point to the parent document URL — anchors
+# have not been verified against current page structure.
+
+# ---------------------------------------------------------------------------
+# Tier 1 — AI-specific Canadian regulatory guidance
+# ---------------------------------------------------------------------------
+
+csa-sn-11-348:
+  title: 'CSA Staff Notice and Consultation 11-348: AI Systems in Capital Markets (2024-12-05)'
+  url: https://www.osc.ca/en/securities-law/instruments-rules-policies/1/11-348/csa-staff-notice-and-consultation-11-348-applicability-canadian-securities-laws-and-use-artificial
+  issuer: CSA
+  description: >
+    The CSA's authoritative view on how existing Canadian securities law applies to AI
+    systems used by market participants. Comment period closed 2025-03-31; CSA may publish
+    a response-to-comments or revised notice in future.
+
+csa-sn-11-348-pdf:
+  title: 'CSA Staff Notice and Consultation 11-348 (full text PDF, OSC hosted)'
+  url: https://www.osc.ca/sites/default/files/2024-12/csa_20241205_11-348_artificial-intelligence-systems-capital-markets.pdf
+  issuer: CSA
+
+ciro-acr-2026:
+  title: 'CIRO Annual Compliance Report 2026 (2026-02-17)'
+  url: https://www.ciro.ca/newsroom/publications/ciro-compliance-report-2026-helping-dealers-compliance
+  issuer: CIRO
+  description: >
+    Includes a dedicated AI section addressing operational controls and the material
+    business change notification trigger when AI adoption constitutes a material change.
+
+# ---------------------------------------------------------------------------
+# Tier 2 — Binding Canadian securities rules and CSA/CIRO staff notices
+# ---------------------------------------------------------------------------
+
+ni-31-103:
+  title: 'NI 31-103: Registration Requirements, Exemptions and Ongoing Registrant Obligations'
+  url: https://www.osc.ca/en/securities-law/instruments-rules-policies/3/31-103/unofficial-consolidation-national-instrument-31-103-registration-requirements-exemptions-and
+  issuer: CSA
+  description: >
+    Core registration, conduct and suitability instrument. Key provisions for AI governance
+    are surfaced as separate entries below (s. 11.1, 11.5, 13.2, 13.2.1, 13.3, 13.4).
+
+ni-31-103-s11-1:
+  title: 'NI 31-103 s. 11.1: Compliance System'
+  url: https://www.osc.ca/en/securities-law/instruments-rules-policies/3/31-103/unofficial-consolidation-national-instrument-31-103-registration-requirements-exemptions-and
+  issuer: CSA
+
+ni-31-103-s11-5:
+  title: 'NI 31-103 s. 11.5: General Records'
+  url: https://www.osc.ca/en/securities-law/instruments-rules-policies/3/31-103/unofficial-consolidation-national-instrument-31-103-registration-requirements-exemptions-and
+  issuer: CSA
+
+ni-31-103-s13-2:
+  title: 'NI 31-103 s. 13.2: Know Your Client (KYC)'
+  url: https://www.osc.ca/en/securities-law/instruments-rules-policies/3/31-103/unofficial-consolidation-national-instrument-31-103-registration-requirements-exemptions-and
+  issuer: CSA
+
+ni-31-103-s13-2-1:
+  title: 'NI 31-103 s. 13.2.1: Know Your Product (KYP)'
+  url: https://www.osc.ca/en/securities-law/instruments-rules-policies/3/31-103/unofficial-consolidation-national-instrument-31-103-registration-requirements-exemptions-and
+  issuer: CSA
+
+ni-31-103-s13-3:
+  title: 'NI 31-103 s. 13.3: Suitability Determination'
+  url: https://www.osc.ca/en/securities-law/instruments-rules-policies/3/31-103/unofficial-consolidation-national-instrument-31-103-registration-requirements-exemptions-and
+  issuer: CSA
+
+ni-31-103-s13-4:
+  title: 'NI 31-103 s. 13.4: Identifying and Addressing Material Conflicts of Interest'
+  url: https://www.osc.ca/en/securities-law/instruments-rules-policies/3/31-103/unofficial-consolidation-national-instrument-31-103-registration-requirements-exemptions-and
+  issuer: CSA
+
+ni-31-103cp:
+  title: 'Companion Policy 31-103CP to NI 31-103'
+  url: https://www.osc.ca/en/securities-law/instruments-rules-policies/3/31-103/unofficial-consolidation-companion-policy-31-103cp-registration-requirements-exemptions-and-1
+  issuer: CSA
+  description: >
+    Interpretive guidance on compliance systems, outsourcing, and the Client Focused Reforms
+    KYC/KYP/suitability/conflicts framework.
+
+csa-ciro-sn-31-363:
+  title: 'Joint CSA/CIRO Staff Notice 31-363: CFR Conflicts of Interest Review'
+  url: https://www.osc.ca/en/securities-law/instruments-rules-policies/3/31-363/joint-canadian-securities-administrators-canadian-investment-regulatory-organization-staff-notice
+  issuer: CSA/CIRO
+  description: >
+    Directly relevant where AI introduces or amplifies material conflicts (e.g., model vendor
+    incentives, auto-generated recommendations).
+
+csa-ciro-sn-31-368:
+  title: 'Joint CSA/CIRO Staff Notice 31-368: CFR KYC/KYP/Suitability Review'
+  url: https://www.osc.ca/en/securities-law/instruments-rules-policies/3/31-368/joint-csaciro-staff-notice-31-368-client-focused-reforms-review-registrants-know-your-client-know
+  issuer: CSA/CIRO
+  description: >
+    Sets the supervisory benchmark for KYC/KYP/suitability processes, including those
+    executed with AI support.
+
+ni-33-109-f5:
+  title: 'NI 33-109 Form 33-109F5: Change of Registration Information'
+  url: https://www.osc.ca/en/securities-law/instruments-rules-policies/3/33-109/unofficial-consolidation-form-33-109f5-change-registration-information
+  issuer: CSA
+  description: >
+    Notification instrument CIRO has flagged as potentially triggered when a dealer's
+    adoption of AI constitutes a material business change.
+
+csa-sn-11-326:
+  title: 'CSA Staff Notice 11-326: Cyber Security (2013-09-26)'
+  url: https://www.osc.ca/en/securities-law/instruments-rules-policies/1/11-326/csa-staff-notice-11-326-cyber-security
+  issuer: CSA
+  description: First CSA cross-sectoral guidance on cyber risk controls for issuers, registrants and regulated entities.
+
+csa-sn-11-332:
+  title: 'CSA Staff Notice 11-332: Cyber Security (2016-09-27)'
+  url: https://www.osc.ca/en/securities-law/instruments-rules-policies/1/11-332/csa-staff-notice-11-332-cyber-security
+  issuer: CSA
+  description: Follow-up notice updating cyber risk expectations and highlighting regulator initiatives.
+
+csa-sn-33-321:
+  title: 'CSA Staff Notice 33-321: Cyber Security and Social Media (2017-10-19)'
+  url: https://www.osc.ca/en/securities-law/instruments-rules-policies/3/33-321/csa-staff-notice-33-321-cyber-security-and-social-media
+  issuer: CSA
+  description: >
+    Survey-driven guidance for investment fund managers, portfolio managers and exempt
+    market dealers on cyber policies, controls, training and incident response.
+
+ciro-idpc-rules:
+  title: 'CIRO Investment Dealer and Partially Consolidated (IDPC) Rules'
+  url: https://www.ciro.ca/sites/default/files/2024-02/IDPC-Rules-022224-EN.pdf
+  issuer: CIRO
+  description: >
+    Currently operative rulebook for CIRO investment dealers, succeeding the legacy IIROC
+    Dealer Member Rules (version dated 2024-02-22). Remains operative pending adoption of
+    the consolidated Proposed CIRO Rules.
+
+ciro-idpc-rule-1500:
+  title: 'CIRO IDPC Rule 1500: Executive Responsibilities'
+  url: https://www.ciro.ca/sites/default/files/2024-02/IDPC-Rules-022224-EN.pdf
+  issuer: CIRO
+
+ciro-idpc-rule-3100-3600:
+  title: 'CIRO IDPC Rules 3100–3600: Business Conduct'
+  url: https://www.ciro.ca/sites/default/files/2024-02/IDPC-Rules-022224-EN.pdf
+  issuer: CIRO
+
+ciro-idpc-rule-3800:
+  title: 'CIRO IDPC Rule 3800: Recordkeeping and Client Reporting'
+  url: https://www.ciro.ca/sites/default/files/2024-02/IDPC-Rules-022224-EN.pdf
+  issuer: CIRO
+
+ciro-idpc-rule-3900:
+  title: 'CIRO IDPC Rule 3900: Supervision'
+  url: https://www.ciro.ca/sites/default/files/2024-02/IDPC-Rules-022224-EN.pdf
+  issuer: CIRO
+
+ciro-dealer-member-rules:
+  title: 'CIRO Dealer Member Rules (landing page)'
+  url: https://www.ciro.ca/rules-and-enforcement/dealer-member-rules
+  issuer: CIRO
+
+ciro-rules-consolidation-project:
+  title: 'CIRO Rule Consolidation Project (landing page)'
+  url: https://www.ciro.ca/rules-and-enforcement/dealer-member-rules/rule-consolidation-project
+  issuer: CIRO
+
+ciro-rules-proposed:
+  title: 'Proposed CIRO Rules (Rule Consolidation Project)'
+  url: https://www.ciro.ca/newsroom/publications/rule-consolidation-project-proposed-ciro-rules
+  issuer: CIRO
+  description: >
+    Full draft consolidated rulebook (formerly "DC Rules") combining the IDPC Rules and the
+    legacy MFD Rules. Phases 1–5 complete in draft; final phase published 2025-03-27, comment
+    period closed 2025-06-25. Subject to revision before coming into force. Rule numbering is
+    carried forward from the IDPC Rules.
+
+ciro-rules-phase-4:
+  title: 'CIRO Rule Consolidation: Phase 4 (2024-10-17)'
+  url: https://www.ciro.ca/newsroom/publications/rule-consolidation-project-phase-4
+  issuer: CIRO
+  description: >
+    Proposed Rule 3100 (business conduct), Rules 3200–3600, and Rule 3900 (supervision).
+    Rule 3900 carries forward a requirement that Dealer Members ensure Supervisors understand
+    how automated tasks and activities work — an explicit AI-adjacent supervisory expectation.
+
+ciro-rules-phase-5:
+  title: 'CIRO Rule Consolidation: Phase 5 (2025-03-27)'
+  url: https://www.ciro.ca/newsroom/publications/rule-consolidation-project-phase-5
+  issuer: CIRO
+  description: >
+    Final phase. Covers proposed Rule 3800 (recordkeeping and client reporting) plus
+    outsourcing, continuing education, complaints handling, financial solvency (proposed
+    DC Form 1), client asset use and custody, and financing arrangements. Comment period
+    closed 2025-06-25.
+
+# ---------------------------------------------------------------------------
+# Tier 3 — Federal prudential and international guidance (analogous; not
+# directly binding on CSA or CIRO registrants but the dominant Canadian
+# benchmarks in their respective domains)
+# ---------------------------------------------------------------------------
+
+osfi-e23-2027:
+  title: 'OSFI Guideline E-23: Model Risk Management (2027)'
+  url: https://www.osfi-bsif.gc.ca/en/guidance/guidance-library/guideline-e-23-model-risk-management-2027
+  issuer: OSFI
+  description: >
+    Final revised version published 2025-09-11, effective 2027-05-01. Applies to FRFIs
+    (banks, foreign bank branches, life insurance and fraternal companies, P&C companies,
+    trust and loan companies) and expressly covers AI/ML models including black-box
+    approaches, autonomous decision-making, model drift and explainability. Not binding on
+    CSA or CIRO registrants but the dominant Canadian benchmark for model risk governance,
+    validation and oversight. Structured as four sections (A. Overview; B. Enterprise-wide
+    model risk management; C. Risk-based approach to model risk management; D. Model
+    lifecycle management) containing 12 numbered principles.
+
+osfi-e23-2027-p1-1:
+  title: 'OSFI E-23 (2027) Principle 1.1: Reporting Structures and Resourcing'
+  url: https://www.osfi-bsif.gc.ca/en/guidance/guidance-library/guideline-e-23-model-risk-management-2027
+  issuer: OSFI
+  description: 'Effective reporting structures and proper resourcing should enable sound model governance.'
+
+osfi-e23-2027-p1-2:
+  title: 'OSFI E-23 (2027) Principle 1.2: Strategy and Risk Appetite Alignment'
+  url: https://www.osfi-bsif.gc.ca/en/guidance/guidance-library/guideline-e-23-model-risk-management-2027
+  issuer: OSFI
+  description: 'The MRM framework should align risk-taking activities to strategic objectives and risk appetite.'
+
+osfi-e23-2027-p1-3:
+  title: 'OSFI E-23 (2027) Principle 1.3: Fit for Business Purpose'
+  url: https://www.osfi-bsif.gc.ca/en/guidance/guidance-library/guideline-e-23-model-risk-management-2027
+  issuer: OSFI
+  description: 'Models should be appropriate for their business purposes.'
+
+osfi-e23-2027-p2-1:
+  title: 'OSFI E-23 (2027) Principle 2.1: Model Inventory and Tracking'
+  url: https://www.osfi-bsif.gc.ca/en/guidance/guidance-library/guideline-e-23-model-risk-management-2027
+  issuer: OSFI
+  description: 'Institutions should identify and track all models in use or recently decommissioned.'
+
+osfi-e23-2027-p2-2:
+  title: 'OSFI E-23 (2027) Principle 2.2: Model Risk Rating Approach'
+  url: https://www.osfi-bsif.gc.ca/en/guidance/guidance-library/guideline-e-23-model-risk-management-2027
+  issuer: OSFI
+  description: 'Institutions should establish a model risk rating approach that assesses key dimensions of model risk.'
+
+osfi-e23-2027-p2-3:
+  title: 'OSFI E-23 (2027) Principle 2.3: Proportional MRM Application'
+  url: https://www.osfi-bsif.gc.ca/en/guidance/guidance-library/guideline-e-23-model-risk-management-2027
+  issuer: OSFI
+  description: 'The scope, scale, and intensity of MRM should be commensurate with the risk introduced by the model.'
+
+osfi-e23-2027-p3-1:
+  title: 'OSFI E-23 (2027) Principle 3.1: Lifecycle Policies, Procedures and Controls'
+  url: https://www.osfi-bsif.gc.ca/en/guidance/guidance-library/guideline-e-23-model-risk-management-2027
+  issuer: OSFI
+  description: >
+    MRM policies, procedures, and controls should be robust, flexible, and lead to effective
+    requirements applied across the model lifecycle.
+
+osfi-e23-2027-p3-2:
+  title: 'OSFI E-23 (2027) Principle 3.2: Data Suitability'
+  url: https://www.osfi-bsif.gc.ca/en/guidance/guidance-library/guideline-e-23-model-risk-management-2027
+  issuer: OSFI
+  description: 'Data used to develop the model should be suitable for the intended use.'
+
+osfi-e23-2027-p3-3:
+  title: 'OSFI E-23 (2027) Principle 3.3: Model Development Standards'
+  url: https://www.osfi-bsif.gc.ca/en/guidance/guidance-library/guideline-e-23-model-risk-management-2027
+  issuer: OSFI
+  description: 'Institutions should have model development processes that set clear standards.'
+
+osfi-e23-2027-p3-4:
+  title: 'OSFI E-23 (2027) Principle 3.4: Independent Assessment of Conceptual Soundness and Performance'
+  url: https://www.osfi-bsif.gc.ca/en/guidance/guidance-library/guideline-e-23-model-risk-management-2027
+  issuer: OSFI
+  description: 'Institutions should have a process to independently assess conceptual soundness and performance.'
+
+osfi-e23-2027-p3-5:
+  title: 'OSFI E-23 (2027) Principle 3.5: Deployment, Quality and Change Control'
+  url: https://www.osfi-bsif.gc.ca/en/guidance/guidance-library/guideline-e-23-model-risk-management-2027
+  issuer: OSFI
+  description: 'Models should be deployed in an environment with quality and change control processes.'
+
+osfi-e23-2027-p3-6:
+  title: 'OSFI E-23 (2027) Principle 3.6: Monitoring and Decommissioning Standards'
+  url: https://www.osfi-bsif.gc.ca/en/guidance/guidance-library/guideline-e-23-model-risk-management-2027
+  issuer: OSFI
+  description: 'Institutions should have defined standards for model monitoring, and model decommission.'
+
+osfi-b13:
+  title: 'OSFI Guideline B-13: Technology and Cyber Risk Management'
+  url: https://www.osfi-bsif.gc.ca/en/guidance/guidance-library/technology-cyber-risk-management
+  issuer: OSFI
+  description: >
+    Published 2022-07-31, effective 2024-01-01. Applies to all FRFIs. Structured as three
+    domains containing 17 numbered principles (Domain 1: principles 1–3; Domain 2:
+    principles 4–13; Domain 3: principles 14–17). Widely cited as the reference framework
+    for AI-system hosting, data protection and incident response.
+
+osfi-b13-d1:
+  title: 'OSFI B-13 Domain 1: Governance and Risk Management'
+  url: https://www.osfi-bsif.gc.ca/en/guidance/guidance-library/technology-cyber-risk-management
+  issuer: OSFI
+  description: 'Principles 1–3. Governance accountabilities, policies, risk appetite, and control frameworks for technology and cyber risk.'
+
+osfi-b13-d2:
+  title: 'OSFI B-13 Domain 2: Technology Operations and Resilience'
+  url: https://www.osfi-bsif.gc.ca/en/guidance/guidance-library/technology-cyber-risk-management
+  issuer: OSFI
+  description: 'Principles 4–13. Resilient operations, incident response, change management, and recovery capabilities.'
+
+osfi-b13-d3:
+  title: 'OSFI B-13 Domain 3: Cyber Security'
+  url: https://www.osfi-bsif.gc.ca/en/guidance/guidance-library/technology-cyber-risk-management
+  issuer: OSFI
+  description: 'Principles 14–17. Layered cyber controls across prevention, detection, response, and recovery.'
+
+iosco-cr-01-2025:
+  title: 'IOSCO CR/01/2025: AI in Capital Markets (2025-03)'
+  url: https://www.iosco.org/library/pubdocs/pdf/IOSCOPD788.pdf
+  issuer: IOSCO
+  description: >
+    International consensus framing from IOSCO's Fintech Task Force. CSA and CIRO approaches
+    to AI in capital markets are inspired by and broadly consistent with the issues, risks
+    and supervisory considerations catalogued in this report.
+
+# ---------------------------------------------------------------------------
+# Tier 4 — Federal privacy and consumer protection (cross-cutting)
+# ---------------------------------------------------------------------------
+
+pipeda:
+  title: 'PIPEDA: Personal Information Protection and Electronic Documents Act'
+  url: https://laws-lois.justice.gc.ca/eng/acts/P-8.6/
+  issuer: OPC
+  description: >
+    Federal private-sector privacy law. Schedule 1 sets out 10 Fair Information Principles
+    (accountability; identifying purposes; consent; limiting collection; limiting use,
+    disclosure and retention; accuracy; safeguards; openness; individual access; challenging
+    compliance), numbered 4.1 through 4.10 in the statute.
+
+pipeda-schedule1:
+  title: 'PIPEDA Schedule 1: Fair Information Principles'
+  url: https://laws-lois.justice.gc.ca/eng/acts/P-8.6/page-7.html#h-417659
+  issuer: OPC
+
+fcac-ai:
+  title: 'FCAC: Artificial Intelligence in Financial Services'
+  url: https://www.canada.ca/en/financial-consumer-agency/services/industry/research/artificial-intelligence-financial-services.html
+  issuer: FCAC
+  description: Consumer-protection framing of AI deployment in financial products and channels.
+
+# NOTE: Bill C-27 (Digital Charter Implementation Act, 2022) — including the proposed
+# Consumer Privacy Protection Act (CPPA) and Artificial Intelligence and Data Act (AIDA) —
+# died on the order paper in the 44th Parliament (last activity at INDU committee
+# 2024-09-26; Parliament prorogued and dissolved without further progress). Not yet
+# reintroduced in the 45th Parliament. Re-add an entry here if and when a successor bill
+# is introduced.

--- a/docs/_layouts/mitigation.html
+++ b/docs/_layouts/mitigation.html
@@ -118,6 +118,11 @@ layout: default
                 dataset="nist-ai-600-1"
                 heading="NIST AI 600-1 References" %}
 
+            {% include reference-card.html
+                references=page.canada-regulations_references
+                dataset="canada-regulations"
+                heading="Canada Regulatory References" %}
+
         </div>
     </div>
 </main>

--- a/docs/_layouts/risk.html
+++ b/docs/_layouts/risk.html
@@ -118,6 +118,11 @@ layout: default
                 dataset="nist-ai-600-1"
                 heading="NIST AI 600-1 References" %}
 
+            {% include reference-card.html
+                references=page.canada-regulations_references
+                dataset="canada-regulations"
+                heading="Canada Regulatory References" %}
+
         </div>
     </div>
 </main>


### PR DESCRIPTION
## Credit

This PR consolidates and restructures the work of two open PRs already on the project. The substantive research is theirs; this PR's contribution is to combine them into a single coherent reference dataset.

- **#285 — Luca Borella** (`Create canada-regulations.yml`): contributed the broader scope (OSFI E-23 and B-13, PIPEDA, CSA, CIRO, FCAC), the layout wiring into `risk.html` and `mitigation.html`, and the practical filename `canada-regulations.yml`.
- **#290 — mthom** (`Add Canada (CSA / CIRO) regulatory reference data file`): contributed current sources (OSFI E-23 *2027*, CIRO Annual Compliance Report 2026, the Proposed CIRO Rules and Phases 4–5, IOSCO CR/01/2025), an explicit perimeter, and a clean schema mirroring `eu-ai-act.yml` / `ffiec-itbooklets.yml`.

If maintainers prefer to land one of the original PRs instead, please feel free to close this one. It is offered as a possible reconciliation of the two and assumes both authors are happy for their work to be combined this way.

## Summary

Adds `docs/_data/canada-regulations.yml` — 48 entries covering Canadian AI and financial-sector regulatory references — and wires the new dataset into the existing reference-card includes on the risk and mitigation layouts.

**Coverage** (issuer / count): OSFI 17 · CSA 14 · CIRO 11 · CSA/CIRO 2 · OPC 2 · IOSCO 1 · FCAC 1.

**Out of scope (deferred to follow-up PRs):** adding `canada-regulations_references:` entries to individual `_risks/*.md` and `_mitigations/*.md` files. This PR is the reference-data foundation only.

## Schema

Mirrors `eu-ai-act.yml` and `ffiec-itbooklets.yml`:

```yaml
key:
  title: <short, single-line citation>
  url: <canonical URL>
  issuer: <CSA | CIRO | CSA/CIRO | OSFI | OPC | FCAC | IOSCO>
  description: <optional richer context; not rendered by current layouts>
```

The `issuer` field is analogous to FFIEC's `booklet_abbrev`. The optional `description` field preserves contextual research (effective dates, applicability, AI relevance) without requiring layout changes today — a future enhancement could surface it as muted secondary text under the title. Happy to drop or rename either field per maintainer preference.

All titles are short single-line citations (longest is 94 characters), consistent with existing reference-card visual norms.

## Granularity

Split where the source has real numbered structure so that follow-up risk/mitigation PRs can cite specifics without churn:

- **OSFI E-23 (2027)** — 12 numbered principles (1.1–1.3, 2.1–2.3, 3.1–3.6) under sections A–D
- **OSFI B-13** — 3 domains (Governance and Risk Management; Technology Operations and Resilience; Cyber Security)
- **NI 31-103** — key sections 11.1, 11.5, 13.2, 13.2.1, 13.3, 13.4
- **CIRO IDPC Rules** — rule groups 1500, 3100–3600, 3800, 3900
- **CIRO Rule Consolidation Project** — Phases 4 and 5 separately
- **PIPEDA** — Schedule 1 separately

Synthetic topical splits (e.g., per-topic CSA SN 11-348 carve-outs) are kept at document level since they don't correspond to real document sections.

## Source verification corrections

While reconciling the two PRs I verified entries against current source documents and made the following corrections:

- **OSFI E-23 (2027)** — restructured to the actual document. The 2027 revision has **12 principles** organised as 1.1–1.3, 2.1–2.3, 3.1–3.6 under sections A–D, not the 7-principle structure of the older E-23 that was in #285.
- **PIPEDA Schedule 1** — URL updated to use the verified anchor (`#h-417659`); description corrected from 9 to 10 principles (the previous summary omitted Principle 4.5, "Limiting Use, Disclosure, and Retention").
- **Bill C-27 (CPPA + AIDA)** — omitted. The bill died on the order paper in the 44th Parliament (last activity at INDU committee 2024-09-26) and has not been reintroduced in the 45th Parliament. A YAML comment notes the trigger for re-adding once a successor bill is introduced.

NI 31-103 sections and CIRO IDPC rule numbers could not be independently verified (BCSC returned 404, OSC and CIRO blanket-403 to automated fetches). The cited section/rule list from #290 was used; it is consistent with the well-known IIROC-inherited IDPC structure.

## Layout wiring

Adds the new dataset to the existing reference-card include block in both `_layouts/risk.html` and `_layouts/mitigation.html`. The include is a no-op for files that don't declare `canada-regulations_references:` in their front matter (the existing `reference-card.html` partial guards on `references.size > 0`), so this change has no visible effect until follow-up PRs add references on individual risks/mitigations.

## Notes on durability

Two entries point to material currently in flux that will need maintenance:

1. **Proposed CIRO Rules** — draft, subject to revision based on comments before coming into force. When adopted, several entries should be updated and the IDPC Rules entry eventually retired.
2. **CSA Staff Notice 11-348** — consultation comment period closed 2025-03-31. CSA may publish a response-to-comments or revised notice in future; this entry should be refreshed at that point.

## Test plan

- [x] `jekyll build` runs cleanly from `docs/` (0.42s, no errors)
- [x] YAML parses; all 48 entries have `title` and `url`; longest title 94 chars
- [ ] Maintainer review of consolidation approach, schema (issuer + optional description), and granularity calls
- [ ] Confirmation from #285 / #290 authors (cc @lucaborella89 @mthomcfa) that they are happy for this combined version to land in place of their PRs