### PR TITLE
Add EU AI Act references to MI-21 Agent Decision Audit

### DIFF
--- a/docs/_mitigations/mi-21_agent-decision-audit-and-explainability.md
+++ b/docs/_mitigations/mi-21_agent-decision-audit-and-explainability.md
@@ -7,6 +7,12 @@ type: DET
 iso-42001_references:
   - A-8-3    # ISO 42001: External reporting
   - A-6-2-6  # ISO 42001: AI system operation and monitoring
+eu-ai-act_references:
+  - c3-s2-a12  # III.S2.A12: Record-keeping
+  - c3-s3-a26  # III.S3.A26: Obligations of Deployers of High-Risk AI Systems
+  - c9-s1-a72  # IX.S1.A72: Post-Market Monitoring by Providers
+  - c3-s2-a13  # III.S2.A13: Transparency and Provision of Information to Deployers
+  - c9-s4-a86  # IX.S4.A86: Right to Explanation of Individual Decision-Making
 nist-sp-800-53r5_references:
   - au-2   # AU-2 Event Logging
   - au-3   # AU-3 Content of Audit Records
@@ -148,6 +154,14 @@ The following sections provide detailed implementation guidance primarily for Ti
   * **Data Processing Documentation**: Record what personal data was used in decisions and the legal basis for processing.
   * **Privacy Impact Documentation**: Capture privacy considerations and impact assessments for decisions affecting customer data.
 
+* **EU AI Act Record-keeping (Article 12)**:
+  * **Technical Requirement under Article 12(1)**: High-risk AI systems must technically allow automatic recording of events over the system lifetime. Tier 3 audit trail implementations described in this mitigation directly satisfy this requirement; Tier 0 and Tier 1 do not meet the threshold for systems classified as high-risk under Annex III.
+  * **Risk Identification under Article 12(2)(a)**: Logging must support identification of situations that may result in the AI system presenting a risk under Article 79(1) or in a substantial modification. Capture guardrail violations, exception paths, and decision boundary crossings.
+  * **Post-Market Monitoring under Article 12(2)(b)**: Logging must facilitate post-market monitoring under Article 72. Capture aggregate behavior metrics, drift indicators, and performance over time.
+  * **Operational Monitoring under Article 12(2)(c)**: Logging must support monitoring of high-risk AI systems under Article 26(5). Capture human review touchpoints, oversight interventions, and operational decisions.
+  * **Biometric ID Extension under Article 12(3)**: For biometric identification systems under Annex III point 1(a), additional structured requirements apply: start/end timestamps per use, reference database identification, input data matches, and identification of natural persons involved in verification.
+  * **Deployer Obligations under Article 26(5)**: Article 26(5) places monitoring obligations on the deployer (bank, insurer, healthcare provider, public administration), not only on the provider. Audit trail design must expose appropriate records to deployer audit interfaces, not only to provider-side observability.
+
 * **Audit Trail Standards**:
   * **Immutable Records**: Implement cryptographic protection to ensure audit records cannot be altered after creation.
   * **Retention Policies**: Establish appropriate retention periods for audit records based on regulatory requirements.
@@ -236,3 +250,6 @@ Implementing comprehensive agent decision audit and explainability provides esse
 * [GDPR Article 22 - Automated Decision-Making](https://gdpr-info.eu/art-22-gdpr/)
 * [NIST AI Risk Management Framework](https://www.nist.gov/itl/ai-risk-management-framework)
 * [FFIEC IT Handbook - Audit](https://ithandbook.ffiec.gov/it-booklets/audit.aspx)
+* [Regulation (EU) 2024/1689 Article 12 - Record-keeping](https://artificialintelligenceact.eu/article/12/)
+* [Regulation (EU) 2024/1689 Article 26 - Obligations of Deployers](https://artificialintelligenceact.eu/article/26/)
+* [Regulation (EU) 2024/1689 Article 72 - Post-Market Monitoring](https://artificialintelligenceact.eu/article/72/)

--- a/docs/_mitigations/mi-21_agent-decision-audit-and-explainability.md
+++ b/docs/_mitigations/mi-21_agent-decision-audit-and-explainability.md
@@ -164,6 +164,7 @@ The following sections provide detailed implementation guidance primarily for Ti
 
 * **Audit Trail Standards**:
   * **Immutable Records**: Implement cryptographic protection to ensure audit records cannot be altered after creation.
+  * **Independent Verifiability**: Distinguish tamper-resistance (records are hard to alter) from tamper-evidence (alteration is detectable by a third party). Audit records should be verifiable by a deployer, auditor, or competent authority without requiring privileged access to the provider's systems. Self-reported logs that only the operator can produce or attest to satisfy the form of Article 12 record-keeping but weaken its purpose: the external-reporting expectation under ISO/IEC 42001 A.8.3 and the deployer monitoring duty under Article 26(5) both assume records an independent party can check. Techniques such as cryptographic hash chaining, signed log segments, or anchoring digests to an append-only transparency log raise integrity from operator-asserted to independently auditable.
   * **Retention Policies**: Establish appropriate retention periods for audit records based on regulatory requirements.
   * **Access Controls**: Implement strict access controls for audit records with appropriate segregation of duties.
 


### PR DESCRIPTION
## Summary

  MI-21 (Agent Decision Audit and Explainability) currently maps to ISO 42001, NIST SP 800-53r5, GDPR, and FFIEC
   IT Handbook, but does not reference Regulation (EU) 2024/1689 (the EU AI Act). Article 12 of the EU AI Act is
   the explicit record-keeping mandate for high-risk AI systems, with enforcement beginning 2026-08-02.

  This PR adds the relevant entries to the `eu-ai-act_references` frontmatter and a new subsection within
  "Regulatory Compliance Integration" mapping the existing four-tier audit model to the specific Article
  12(2)(a-c) requirements, plus the Article 12(3) biometric extension and Article 26(5) deployer obligations.

  ## Changes

  - Add `eu-ai-act_references` block with 5 citations (Articles 12, 13, 26, 72, 86)
  - Add new subsection "EU AI Act Record-keeping (Article 12)" in section 3 (Regulatory Compliance Integration),
   with 6 sub-bullets mapping the tier model to specific Article 12 subsections
  - Add 3 EU AI Act article links to "Additional Resources"

  ## Notes

  - Strictly additive change to an Approved-Specification document; no removed or modified content.
  - The deployer-side framing (Article 26(5)) is included because Article 12 record-keeping obligations apply to
   both providers and deployers, and the latter is often underemphasized in AI governance documentation.