### PR TITLE
docs(canada): map CSA/CIRO references into 8 AIGF risks (follow-up to #290)

### DIFF
--- a/docs/_data/csa-ciro-canada.yml
+++ b/docs/_data/csa-ciro-canada.yml
@@ -1,0 +1,149 @@
+# Canada — CSA / CIRO regulatory references for AI governance in securities markets
+# Schema mirrors docs/_data/eu-ai-act.yml and docs/_data/ffiec-itbooklets.yml.
+# Each entry is <key>: { title, url, issuer }. The `issuer` field is an
+# optional extension field analogous to `booklet_abbrev` in ffiec-itbooklets.yml
+# and denotes the publishing authority (CSA, CIRO, CSA/CIRO jointly, OSFI,
+# or IOSCO).
+#
+# Scope:
+#   Canada does not have a single horizontal AI statute applicable to capital
+#   markets participants. Obligations for firms registered with CSA members
+#   and/or CIRO are composed from (i) AI-specific staff guidance, (ii) general
+#   registration / conduct / recordkeeping rules that bind AI use cases as
+#   they would any other system, and (iii) analogous federal prudential
+#   guidance (OSFI) and international consensus material (IOSCO) that is not
+#   itself binding on securities registrants but is widely referenced as
+#   benchmark.
+#
+# Perimeter:
+#   - CIRO investment dealers (currently governed by the IDPC Rules, which
+#     succeeded the legacy IIROC Dealer Member Rules). CIRO's Rule
+#     Consolidation Project is complete in draft across Phases 1–5 (final
+#     phase published 2025-03-27, comment period closed 2025-06-25). The
+#     consolidated "Proposed CIRO Rules" (previously titled "DC Rules") will
+#     replace the IDPC Rules and the MFD Rules in a single unified rulebook
+#     once finalized, subject to updates in response to comments received
+#     before coming into force in combined form.
+#   - CSA-registered portfolio managers, investment fund managers, and
+#     exempt market dealers (non-CIRO registrants under NI 31-103).
+#   Mutual fund dealers (legacy MFDA rulebook) and marketplaces are
+#   intentionally out of scope for this initial mapping and may be added
+#   in follow-up contributions.
+
+
+# =============================================================================
+# Tier 1 — AI-specific Canadian regulatory guidance
+# =============================================================================
+
+csa-sn-11-348:
+  title: 'CSA Staff Notice and Consultation 11-348: Applicability of Canadian Securities Laws and the Use of Artificial Intelligence Systems in Capital Markets (2024-12-05)'
+  url: https://www.osc.ca/en/securities-law/instruments-rules-policies/1/11-348/csa-staff-notice-and-consultation-11-348-applicability-canadian-securities-laws-and-use-artificial
+  issuer: CSA
+
+csa-sn-11-348-pdf:
+  title: 'CSA Staff Notice and Consultation 11-348 (full text PDF, OSC hosted)'
+  url: https://www.osc.ca/sites/default/files/2024-12/csa_20241205_11-348_artificial-intelligence-systems-capital-markets.pdf
+  issuer: CSA
+
+ciro-acr-2026:
+  title: 'CIRO Compliance Report for 2026 — includes dedicated guidance on the use of artificial intelligence in dealer operations, FinOps examination posture, and the material-change notification trigger (2026-02-17)'
+  url: https://www.ciro.ca/newsroom/publications/ciro-compliance-report-2026-helping-dealers-compliance
+  issuer: CIRO
+
+
+# =============================================================================
+# Tier 2 — Canadian securities rules and staff notices binding on registrants
+# (apply to AI use cases as they apply to any other system or process)
+# =============================================================================
+
+ni-31-103:
+  title: 'National Instrument 31-103 Registration Requirements, Exemptions and Ongoing Registrant Obligations (unofficial consolidation, OSC) — key provisions for AI governance include s. 11.1 (compliance system), s. 11.5 (general records), s. 13.2 (know your client), s. 13.2.1 (know your product), s. 13.3 (suitability determination), and s. 13.4 (identifying and addressing material conflicts of interest)'
+  url: https://www.osc.ca/en/securities-law/instruments-rules-policies/3/31-103/unofficial-consolidation-national-instrument-31-103-registration-requirements-exemptions-and
+  issuer: CSA
+
+ni-31-103cp:
+  title: 'Companion Policy 31-103CP Registration Requirements, Exemptions and Ongoing Registrant Obligations (unofficial consolidation, OSC) — interpretive guidance on compliance systems, outsourcing, and the Client Focused Reforms KYC/KYP/suitability/conflicts framework'
+  url: https://www.osc.ca/en/securities-law/instruments-rules-policies/3/31-103/unofficial-consolidation-companion-policy-31-103cp-registration-requirements-exemptions-and-1
+  issuer: CSA
+
+csa-ciro-sn-31-363:
+  title: 'Joint CSA / CIRO Staff Notice 31-363 Client Focused Reforms: Review of Registrants'' Conflicts of Interest Practices and Additional Guidance — directly relevant where AI introduces or amplifies material conflicts (e.g., model vendor incentives, auto-generated recommendations)'
+  url: https://www.osc.ca/en/securities-law/instruments-rules-policies/3/31-363/joint-canadian-securities-administrators-canadian-investment-regulatory-organization-staff-notice
+  issuer: CSA/CIRO
+
+csa-ciro-sn-31-368:
+  title: 'Joint CSA / CIRO Staff Notice 31-368 Client Focused Reforms: Review of Registrants'' Know Your Client, Know Your Product and Suitability Determination Practices and Additional Guidance — sets the supervisory benchmark for KYC/KYP/suitability processes, including those executed with AI support'
+  url: https://www.osc.ca/en/securities-law/instruments-rules-policies/3/31-368/joint-csaciro-staff-notice-31-368-client-focused-reforms-review-registrants-know-your-client-know
+  issuer: CSA/CIRO
+
+ni-33-109-f5:
+  title: 'National Instrument 33-109 Form 33-109F5 Change of Registration Information (unofficial consolidation, OSC) — the notification instrument CIRO has flagged as potentially triggered when a dealer''s adoption of AI constitutes a material business change'
+  url: https://www.osc.ca/en/securities-law/instruments-rules-policies/3/33-109/unofficial-consolidation-form-33-109f5-change-registration-information
+  issuer: CSA
+
+csa-sn-11-326:
+  title: 'CSA Staff Notice 11-326 Cyber Security (2013-09-26) — first CSA cross-sectoral guidance on cyber risk controls for issuers, registrants and regulated entities'
+  url: https://www.osc.ca/en/securities-law/instruments-rules-policies/1/11-326/csa-staff-notice-11-326-cyber-security
+  issuer: CSA
+
+csa-sn-11-332:
+  title: 'CSA Staff Notice 11-332 Cyber Security (2016-09-27) — follow-up notice updating cyber risk expectations and highlighting regulator initiatives'
+  url: https://www.osc.ca/en/securities-law/instruments-rules-policies/1/11-332/csa-staff-notice-11-332-cyber-security
+  issuer: CSA
+
+csa-sn-33-321:
+  title: 'CSA Staff Notice 33-321 Cyber Security and Social Media (2017-10-19) — survey-driven guidance for investment fund managers, portfolio managers and exempt market dealers on cyber policies, controls, training and incident response'
+  url: https://www.osc.ca/en/securities-law/instruments-rules-policies/3/33-321/csa-staff-notice-33-321-cyber-security-and-social-media
+  issuer: CSA
+
+ciro-idpc-rules:
+  title: 'CIRO Investment Dealer and Partially Consolidated (IDPC) Rules — currently operative rulebook for CIRO investment dealers, succeeding the legacy IIROC Dealer Member Rules. Rule 1500 addresses executive responsibilities; Rules 3100–3600 govern business conduct; Rule 3800 governs recordkeeping and client reporting; Rule 3900 governs supervision. All apply to AI-enabled activities. The Proposed CIRO Rules carry these numberings forward under the same rule numbers (see ciro-rules-proposed, ciro-rules-phase-4 and ciro-rules-phase-5 for the corresponding draft consolidated provisions). (Version dated 2024-02-22; remains the operative rulebook pending adoption of the consolidated Proposed CIRO Rules.)'
+  url: https://www.ciro.ca/sites/default/files/2024-02/IDPC-Rules-022224-EN.pdf
+  issuer: CIRO
+
+ciro-dealer-member-rules:
+  title: 'CIRO Dealer Member Rules landing page — entry point to the current IDPC rulebook, bulletins, and the Rule Consolidation Project materials covering Phases 1 through 5'
+  url: https://www.ciro.ca/rules-and-enforcement/dealer-member-rules
+  issuer: CIRO
+
+ciro-rules-proposed:
+  title: 'Rule Consolidation Project — Proposed CIRO Rules (formerly "DC Rules") — the full draft consolidated rulebook combining the IDPC Rules and the legacy MFD Rules into a single unified CIRO rulebook. Phase 5, the final phase of the consolidation, was published for comment on 2025-03-27 with the comment period closing 2025-06-25; the Proposed CIRO Rules aggregate Phases 1 through 5 together with further proposed amendments. Rule numbering is carried forward from the IDPC Rules: Rule 1500 (executive responsibilities), Rules 3100–3600 (business conduct), Rule 3800 (recordkeeping and client reporting), Rule 3900 (supervision). The draft rules are subject to updates in response to comments received before coming into force in combined form, and the IDPC Rules remain operative for CIRO investment dealers until that occurs.'
+  url: https://www.ciro.ca/newsroom/publications/rule-consolidation-project-proposed-ciro-rules
+  issuer: CIRO
+
+ciro-rules-consolidation-project:
+  title: 'CIRO Rule Consolidation Project landing page — project overview, phase-by-phase materials, bulletins, and the current status of the transition from IDPC Rules and legacy MFD Rules to the unified Proposed CIRO Rules'
+  url: https://www.ciro.ca/rules-and-enforcement/dealer-member-rules/rule-consolidation-project
+  issuer: CIRO
+
+ciro-rules-phase-4:
+  title: 'Rule Consolidation Project — Phase 4 (published 2024-10-17) — proposes the consolidated business conduct and supervision rules: proposed CIRO Rule 3100 (business conduct), Rules 3200–3600, and Rule 3900 (supervision). Includes a blackline to the IDPC Rules and a table of concordance. Of direct relevance to AI governance: proposed Rule 3900 carries forward a requirement that Dealer Members ensure relevant Supervisors understand how automated tasks and activities work — an explicit supervisory expectation for automated and AI-assisted systems.'
+  url: https://www.ciro.ca/newsroom/publications/rule-consolidation-project-phase-4
+  issuer: CIRO
+
+ciro-rules-phase-5:
+  title: 'Rule Consolidation Project — Phase 5 (published 2025-03-27, comment period closed 2025-06-25) — the final phase of the consolidation. Covers proposed CIRO Rule 3800 (recordkeeping and client reporting) along with outsourcing and service arrangements, continuing education, reporting and handling of complaints, internal investigations and other reportable matters, financial solvency (proposed DC Form 1), client asset use and custody, and financing arrangements. Subject to updates in response to comments received before coming into force.'
+  url: https://www.ciro.ca/newsroom/publications/rule-consolidation-project-phase-5
+  issuer: CIRO
+
+
+# =============================================================================
+# Tier 3 — Not binding on securities registrants, but broadly consistent with
+# or referenced alongside CSA / CIRO expectations. Useful where a control or
+# risk in the AIGF has no direct Canadian securities-law analogue.
+# =============================================================================
+
+osfi-e-23-2027:
+  title: 'OSFI Guideline E-23 Model Risk Management (2027) — final revised version published 2025-09-11, effective 2027-05-01. Applies to federally regulated financial institutions (banks, insurers, trust and loan companies) and expressly covers AI / machine learning models. Not binding on CSA or CIRO registrants as such, but the dominant Canadian benchmark for model risk governance, validation, and oversight.'
+  url: https://www.osfi-bsif.gc.ca/en/guidance/guidance-library/guideline-e-23-model-risk-management-2027
+  issuer: OSFI
+
+osfi-b-13:
+  title: 'OSFI Guideline B-13 Technology and Cyber Risk Management — effective 2024-01-01. Applies to federally regulated financial institutions. Sets expectations for technology governance, risk management, operations, resilience, and cyber security. Widely cited as the reference framework for AI-system hosting, data protection, and incident response even where not directly binding.'
+  url: https://www.osfi-bsif.gc.ca/en/guidance/guidance-library/technology-cyber-risk-management
+  issuer: OSFI
+
+iosco-cr-01-2025:
+  title: 'IOSCO Consultation Report CR/01/2025 Artificial Intelligence in Capital Markets: Use Cases, Risks, and Challenges (2025-03, IOSCOPD788) — international consensus framing from IOSCO''s Fintech Task Force. CSA and CIRO approaches to AI in capital markets are inspired by and broadly consistent with the issues, risks and supervisory considerations catalogued in this report.'
+  url: https://www.iosco.org/library/pubdocs/pdf/IOSCOPD788.pdf
+  issuer: IOSCO

--- a/docs/_data/csa-ciro-canada.yml
+++ b/docs/_data/csa-ciro-canada.yml
@@ -57,7 +57,7 @@ ciro-acr-2026:
 # =============================================================================
 
 ni-31-103:
-  title: 'National Instrument 31-103 Registration Requirements, Exemptions and Ongoing Registrant Obligations (unofficial consolidation, OSC) — key provisions for AI governance include s. 11.1 (compliance system), s. 11.5 (general records), s. 13.2 (know your client), s. 13.2.1 (know your product), s. 13.3 (suitability determination), and s. 13.4 (identifying and addressing material conflicts of interest)'
+  title: 'National Instrument 31-103 Registration Requirements, Exemptions and Ongoing Registrant Obligations (unofficial consolidation, OSC) — key provisions for AI governance include s. 11.1 (compliance system), s. 11.5 (general records), s. 13.2 (know your client), s. 13.2.1 (know your product), s. 13.3 (suitability determination), s. 13.4 (identifying and addressing material conflicts of interest), and s. 14.2 (relationship disclosure information)'
   url: https://www.osc.ca/en/securities-law/instruments-rules-policies/3/31-103/unofficial-consolidation-national-instrument-31-103-registration-requirements-exemptions-and
   issuer: CSA
 
@@ -126,6 +126,31 @@ ciro-rules-phase-5:
   url: https://www.ciro.ca/newsroom/publications/rule-consolidation-project-phase-5
   issuer: CIRO
 
+ciro-gn-2300-21-003:
+  title: 'CIRO Guidance Note GN-2300-21-003 Outsourcing Arrangements (effective 2021-12-31) — operative CIRO outsourcing framework for investment dealers. Requires: due diligence in selecting third-party service providers, legally binding written contracts with SLA provisions, ongoing performance monitoring, exit/contingency planning, and enhanced due diligence for cross-border material functions. Actively referenced by the CIRO 2026 Compliance Report in the context of third-party AI service providers. Remains in force pending adoption of proposed DC Rules 2403/2407/2409 under the Rule Consolidation Project (Phase 5). Read alongside NI 31-103 s. 11.1 and Companion Policy 31-103CP Part 11, which set the CSA-level outsourcing obligations that this guidance note implements for CIRO members.'
+  url: https://www.ciro.ca/newsroom/publications/outsourcing-arrangements-0
+  issuer: CIRO
+
+ni-81-102:
+  title: 'National Instrument 81-102 Investment Funds — key provisions for AI governance: s. 5.1(1)(c) requires prior securityholder approval when adopting AI as a material investment strategy constitutes a change to fundamental investment objectives. Part 15 sales communications rules prohibit misleading AI claims in marketing materials and offering documents; CSA SN 11-348 explicitly flags "AI washing" as a compliance risk. IFMs must accurately disclose and clearly explain how AI systems are used and integrated in the fund''s operations.'
+  url: https://www.osc.ca/en/securities-law/instruments-rules-policies/8/81-102
+  issuer: CSA
+
+ni-81-107:
+  title: 'National Instrument 81-107 Independent Review Committee for Investment Funds — s. 5.1 requires IFMs to refer AI-related conflicts of interest to the IRC before acting, including use of proprietary or affiliated AI models and vendor relationships where the manager has a financial interest in the AI provider. s. 5.2 requires prior IRC approval for related-party AI transactions. CSA SN 11-348 identifies AI-specific conflict scenarios: proprietary model use, vendor selection incentives, and AI systems that systematically favor related-party assets.'
+  url: https://www.osc.ca/en/securities-law/instruments-rules-policies/8/81-107
+  issuer: CSA
+
+ni-81-106:
+  title: 'National Instrument 81-106 Investment Fund Continuous Disclosure — s. 1.1 defines "material change" as a change in business, operations, or affairs important to a reasonable investor''s hold/purchase decision. Adopting AI as a material part of fund operations likely triggers material change reporting (Part 11), requiring a material change report and press release. Complements the NI 81-102 offering document disclosure obligation.'
+  url: https://www.osc.ca/en/securities-law/instruments-rules-policies/8/81-106
+  issuer: CSA
+
+csa-sn-31-342:
+  title: 'CSA Staff Notice 31-342 Guidance for Portfolio Managers Regarding Online Advice (2015-09-24, current) — establishes the human oversight floor for automated/AI-assisted portfolio management. Advising representatives must remain actively responsible for suitability determinations — AI cannot substitute for the AR as decision-maker. KYC via automated means is permissible only where the AR reviews and validates sufficiency. Reinforced by CSA SN 11-348 (2024), which states staff do not believe it is currently possible to use an AI system as a substitute for an AR and consistently satisfy regulatory requirements.'
+  url: https://www.osc.ca/en/securities-law/instruments-rules-policies/3/31-342/csa-staff-notice-31-342-guidance-portfolio-managers-regarding-online-advice
+  issuer: CSA
+
 
 # =============================================================================
 # Tier 3 — Not binding on securities registrants, but broadly consistent with
@@ -143,7 +168,81 @@ osfi-b-13:
   url: https://www.osfi-bsif.gc.ca/en/guidance/guidance-library/technology-cyber-risk-management
   issuer: OSFI
 
-iosco-cr-01-2025:
-  title: 'IOSCO Consultation Report CR/01/2025 Artificial Intelligence in Capital Markets: Use Cases, Risks, and Challenges (2025-03, IOSCOPD788) — international consensus framing from IOSCO''s Fintech Task Force. CSA and CIRO approaches to AI in capital markets are inspired by and broadly consistent with the issues, risks and supervisory considerations catalogued in this report.'
-  url: https://www.iosco.org/library/pubdocs/pdf/IOSCOPD788.pdf
+iosco-fr-02-2026:
+  title: 'IOSCO Final Report FR/02/2026 Supervisory Toolkit for AI Use in Capital Markets (2026-05-25) — practical, non-binding supervisory toolkit covering the full AI lifecycle across traditional ML, Generative AI, and Agentic AI. Five areas of focus: (i) governance and risk management, (ii) third-party and outsourcing risk management, (iii) disclosure, (iv) recordkeeping and reporting, and (v) monitoring AI use. Supersedes the consultation report CR/01/2025 (IOSCOPD788). CSA and CIRO supervisory approaches to AI in capital markets are broadly consistent with the issues, risks, and supervisory considerations in this toolkit.'
+  url: https://www.iosco.org/library/pubdocs/pdf/IOSCOPD823.pdf
   issuer: IOSCO
+
+qc-amf-ai-guideline:
+  title: 'AMF Guideline for the Use of Artificial Intelligence (finalized 2026-03-30, effective 2027-05-01) — applies to Quebec-authorized insurers, financial services cooperatives, deposit-taking institutions, and trust companies. Requires lifecycle risk management, governance mechanisms, and protection of client interests; covers biased outputs, discriminatory proxies, ethical misalignment, and hallucinations. The AMF is also Quebec''s securities regulator (CSA member), but this guideline applies to its prudential registrants, not securities registrants under CSA/CIRO. Included as a peer benchmark to OSFI E-23 and the most operationally specific Canadian AI instrument for financial services.'
+  url: https://lautorite.qc.ca/en/professionals/insurers/guidelines/use-of-models/guideline-for-the-use-of-artificial-intelligence
+  issuer: AMF
+
+osfi-b-10:
+  title: 'OSFI Guideline B-10 Third-Party Risk Management — published 2023-04-30 (category: Sound Business and Financial Practices), effective 2024-05-01. Applies to federally regulated financial institutions (banks, foreign bank branches, foreign insurance branches, life insurance and fraternal companies, P&C companies, trust and loan companies). A general (not AI-specific) third-party risk management guideline: it governs all third-party arrangements across their lifecycle (risk-based approach, due diligence, contractual provisions, ongoing monitoring, business continuity, and exit) and defines institution-specific and systemic concentration risk. AI and model vendors (e.g., cloud and hosted-inference providers, "technology companies that deliver financial services") fall within its third-party scope, and OSFI E-23 (2027) relies on B-10 for third-party model-vendor risk. Binding only on FRFIs; not binding on CSA or CIRO registrants, for whom it is persuasive federal-prudential practice rather than a securities-law obligation (the binding outsourcing hooks for registrants are NI 31-103 s. 11.1 and CIRO GN-2300-21-003).'
+  url: https://www.osfi-bsif.gc.ca/en/guidance/guidance-library/third-party-risk-management-guideline
+  issuer: OSFI
+
+
+# =============================================================================
+# Tier 4 — Adjacent legislative and regulatory frameworks in Canada
+#
+# These statutes and codes are not securities regulation but are directly
+# binding on or relevant to securities-registered firms operating in Canada.
+# They are included for awareness: a CIRO investment dealer or CSA registrant
+# deploying AI systems is subject to these frameworks in parallel with the
+# securities obligations catalogued in Tiers 1–2 above.
+#
+# RFC to maintainers: This Tier 4 introduces adjacent (non-core-regulator)
+# legislation into a jurisdictional reference data file. Maintainer input
+# welcomed on whether this should become a convention for jurisdictional
+# contributions or whether adjacent obligations should live in separate
+# per-statute data files. Proposed admission criteria applied here:
+#   (i)   Directly binding on entities within the jurisdictional perimeter
+#         (not generally applicable to all businesses)
+#   (ii)  Materially affects AI deployment risk for those entities
+#         (not incidental)
+#   (iii) Compensates for an absence in the core regulatory framework
+#         (the gap is not already covered by securities regulation)
+#   (iv)  Maximum five entries per Tier 4 block to prevent scope creep
+#   (v)   Each entry must be referenced in at least one risk file mapping
+#
+# Investment dealers are provincially regulated for constitutional purposes
+# (Constitution Act, 1867, s. 92(13) — property and civil rights). The
+# Canadian Human Rights Act does not apply to them; the applicable
+# anti-discrimination framework is the human rights code of each province
+# in which the firm operates. PIPEDA applies to interprovincial and
+# international commercial activity; within Alberta, British Columbia, and
+# Quebec, substantially similar provincial privacy statutes apply instead
+# (PIPEDA s. 26(2)(b)).
+#
+# Canada has no enacted federal AI-specific statute. The Artificial
+# Intelligence and Data Act (AIDA), proposed as Part 3 of Bill C-27, died
+# on the Order Paper when Parliament prorogued on 2025-01-06. No successor
+# bill has been introduced as of 2026-05-28.
+# =============================================================================
+
+pipeda:
+  title: 'Personal Information Protection and Electronic Documents Act (PIPEDA), SC 2000, c 5 — federal private-sector privacy statute. Key provisions for AI governance: Principle 4.1.3 (accountability for third-party processors, including AI service providers), Principle 4.4 (limiting collection to identified purposes), Principle 4.5 (limiting use and disclosure), Principle 4.7 (security safeguards appropriate to sensitivity), s. 6.1 (meaningful consent), and s. 10.1 with SOR/2018-64 (mandatory breach notification where real risk of significant harm). Contains no AI-specific or automated decision-making provisions. Within Alberta, BC, and Quebec, substantially similar provincial statutes displace PIPEDA for intra-provincial activity.'
+  url: https://laws-lois.justice.gc.ca/eng/acts/p-8.6/
+  issuer: OPC
+
+qc-p39-s12-1:
+  title: 'Quebec Act respecting the protection of personal information in the private sector (CQLR c P-39.1), s. 12.1 — automated decision-making transparency (in force 2023-09-22, as amended by Law 25 / 2021, c 25). Where a decision is based exclusively on automated processing of personal information, the organization must inform the individual at the time of the decision and, on request, disclose the personal information used, the principal factors and parameters of the decision, and the individual''s right to have the information corrected and to submit observations to a human decision-maker. The only Canadian private-sector statute imposing an enforceable right to explanation for automated decisions. Penalties up to C$25 million or 4% of worldwide turnover.'
+  url: https://www.legisquebec.gouv.qc.ca/en/document/cs/P-39.1
+  issuer: CAI
+
+qc-p39-s3-3-s17:
+  title: 'Quebec Act respecting the protection of personal information in the private sector (CQLR c P-39.1), ss. 3.3 and 17 — privacy impact assessments and cross-border transfers (in force 2023-09-22, as amended by Law 25 / 2021, c 25). Section 3.3 requires a mandatory privacy impact assessment before any processing presenting a significant privacy risk, including AI and automated decision-making systems. Section 17 requires, before communicating personal information outside Quebec, a PIA establishing that the receiving jurisdiction provides adequate protection based on generally recognized principles, plus a written agreement with the recipient. Material compliance obligation for Quebec-based firms using AI models hosted outside Canada.'
+  url: https://www.legisquebec.gouv.qc.ca/en/document/cs/P-39.1
+  issuer: CAI
+
+chra-s3-s5:
+  title: 'Canadian Human Rights Act (CHRA), RSC 1985, c H-6, ss. 3 and 5 — federal anti-discrimination statute. Section 3(1) establishes prohibited grounds of discrimination (race, national or ethnic origin, colour, religion, age, sex, sexual orientation, gender identity or expression, marital status, family status, genetic characteristics, disability). Section 5 makes it a discriminatory practice to deny or differentiate adversely in the provision of services on a prohibited ground. Applies to federally regulated entities only (chartered banks, federal Crown corporations, telecoms, airlines). Does NOT apply to investment dealers or other provincially regulated securities registrants — for those firms, the applicable anti-discrimination framework is the human rights code of each province in which the firm operates (see on-hrc-s1 for a representative provincial provision).'
+  url: https://laws-lois.justice.gc.ca/eng/acts/h-6/
+  issuer: CHRC
+
+on-hrc-s1:
+  title: 'Ontario Human Rights Code, RSO 1990, c H.19, s. 1 — equal treatment in services, goods, and facilities without discrimination on grounds including race, ancestry, place of origin, colour, ethnic origin, citizenship, creed, sex, sexual orientation, gender identity or expression, age, marital status, family status, and disability (s. 1); extends to contract rights (s. 3). Representative of provincial human rights legislation applicable to investment dealers and other securities registrants. Equivalent provisions exist in Quebec (Charter of Human Rights and Freedoms, CQLR c C-12, ss. 10, 12), British Columbia (Human Rights Code, RSBC 1996, c 210, s. 8), Alberta (Alberta Human Rights Act, RSA 2000, c A-25.5, s. 4), and all other provinces and territories. No Canadian provincial human rights code contains AI-specific provisions; the adverse-effect discrimination doctrine (SCC, Ontario (Human Rights Commission) v. Simpsons-Sears Ltd., [1985] 2 SCR 536) applies to algorithmic outputs by extension.'
+  url: https://www.ontario.ca/laws/statute/90h19
+  issuer: OHRC

--- a/docs/_layouts/mitigation.html
+++ b/docs/_layouts/mitigation.html
@@ -118,6 +118,11 @@ layout: default
                 dataset="nist-ai-600-1"
                 heading="NIST AI 600-1 References" %}
 
+            {% include reference-card.html
+                references=page.csa-ciro-canada_references
+                dataset="csa-ciro-canada"
+                heading="Canada (CSA / CIRO) Regulatory References" %}
+
         </div>
     </div>
 </main>

--- a/docs/_layouts/risk.html
+++ b/docs/_layouts/risk.html
@@ -118,6 +118,11 @@ layout: default
                 dataset="nist-ai-600-1"
                 heading="NIST AI 600-1 References" %}
 
+            {% include reference-card.html
+                references=page.csa-ciro-canada_references
+                dataset="csa-ciro-canada"
+                heading="Canada (CSA / CIRO) Regulatory References" %}
+
         </div>
     </div>
 </main>

--- a/docs/_risks/ri-16_bias-and-discrimination.md
+++ b/docs/_risks/ri-16_bias-and-discrimination.md
@@ -16,6 +16,17 @@ eu-ai-act_references:
   - c3-s2-a10  # III.S2.A10: Data and Data Governance
   - c3-s2-a14  # III.S2.A14: Human Oversight
   - c3-s3-a27  # III.S3.A27: Fundamental Rights Impact Assessment for High-Risk AI Systems
+csa-ciro-canada_references:
+  # Securities guidance
+  - csa-sn-11-348        # CSA SN 11-348: identifies systemic AI bias as a market fairness risk
+  - ni-81-107             # IRC referral for AI-related conflicts — bias from proprietary/affiliated models
+  # Tier 3 benchmarks
+  - osfi-e-23-2027        # OSFI E-23 Principle 3.2 — unwanted bias in model data/outputs (FRFIs, 2027)
+  - qc-amf-ai-guideline   # AMF AI Guideline — covers biased outputs and discriminatory proxies (QC FIs, 2027)
+  - iosco-fr-02-2026      # IOSCO Toolkit Section 3.1 — bias/fairness in AI governance
+  # Tier 4 — operative anti-discrimination framework
+  - on-hrc-s1             # Provincial human rights codes — equal treatment in services
+  - chra-s3-s5            # CHRA ss. 3, 5 — federal anti-discrimination (federally regulated FIs only)
 related_risks:
   - ri-19  # Data Quality and Drift
   - ri-22  # Regulatory Compliance and Oversight

--- a/docs/_risks/ri-17_lack-of-explainability.md
+++ b/docs/_risks/ri-17_lack-of-explainability.md
@@ -14,6 +14,23 @@ eu-ai-act_references:
   - c3-s2-a14  # III.S2.A14: Human Oversight
   - c4-a50     # IV.A50 Transparency Obligations for Providers and Deployers of Certain AI Systems
   - c9-s4-a86  # IX.S4.A86: Right to Explanation of Individual Decision-Making
+csa-ciro-canada_references:
+  # Reasonable-basis doctrine
+  - csa-sn-11-348        # CSA SN 11-348: explainability/governance expectations for AI
+  - ni-31-103             # s. 13.3 (reasonable basis), s. 13.2.1 (KYP), s. 14.2 (relationship disclosure)
+  - csa-ciro-sn-31-368   # Joint CFR review — supervisory benchmark for demonstrating reasonable basis
+  - csa-sn-31-342         # Online advice — AR must remain decision-maker for registerable activities
+  # Supervision and oversight
+  - ciro-rules-phase-4    # Proposed Rule 3900/3907 — supervisors must understand automated tasks
+  - ciro-idpc-rules       # Operative Rule 3900 (supervision) — understanding processes being supervised
+  # Investment funds
+  - ni-81-102             # Offering document disclosure must clearly articulate how AI is used
+  # Statutory explanation right
+  - qc-p39-s12-1          # Quebec Law 25 s. 12.1 — only Canadian private-sector ADM explanation right
+  # Tier 3 benchmarks
+  - osfi-e-23-2027        # OSFI E-23 — model documentation/validation (FRFIs, 2027)
+  - qc-amf-ai-guideline   # AMF AI Guideline — lifecycle controls imply explainability (QC FIs, 2027)
+  - iosco-fr-02-2026      # IOSCO Toolkit Section 3.3 (Disclosure) — AI transparency
 related_risks:
   - ri-22  # Regulatory Compliance and Oversight
   - ri-16  # Bias and Discrimination

--- a/docs/_risks/ri-18_model-overreach-expanded-use.md
+++ b/docs/_risks/ri-18_model-overreach-expanded-use.md
@@ -14,6 +14,23 @@ eu-ai-act_references:
   - c3-s1-a6   # III.S1.A6: Classification Rules for High-Risk AI Systems
   - c3-s2-a14  # III.S2.A14: Human Oversight
   - c3-s3-a26  # III.S3.A26: Obligations of Deployers of High-Risk AI Systems
+csa-ciro-canada_references:
+  # Scope control and notification
+  - csa-sn-11-348        # CSA SN 11-348: AI governance/scope expectations
+  - ni-33-109-f5          # Form 33-109F5 — material business change notification
+  - ni-81-102             # s. 5.1(1)(c) — AI as material strategy = fundamental change, securityholder approval
+  - ni-81-106             # Part 11 material change reporting — AI scope expansion as a material change in fund operations
+  # Supervision and human oversight
+  - ciro-rules-phase-4    # Proposed Rules 3900/3907 — supervision of automated tasks
+  - ciro-acr-2026         # CIRO 2026 Compliance Report — AI operational controls and scope
+  - csa-sn-31-342         # AR must remain decision-maker — AI assists but cannot substitute
+  # Outsourcing / third-party oversight
+  - ni-31-103             # s. 11.1 — outsourcing obligations; registrant accountable for third-party AI scope
+  - ni-31-103cp           # CP Part 11 — registerable-vs-support activity: AI may assist but not substitute
+  - ciro-gn-2300-21-003   # Outsourcing Arrangements — monitoring for scope expansion by service providers
+  # Tier 3 benchmarks
+  - osfi-e-23-2027        # OSFI E-23 — model lifecycle monitoring catches scope drift (FRFIs, 2027)
+  - osfi-b-10             # OSFI B-10 — third-party risk management and concentration (FRFIs)
 related_risks:
   - ri-10  # Prompt Injection
   - ri-17  # Lack of Explainability

--- a/docs/_risks/ri-19_data-quality-and-drift.md
+++ b/docs/_risks/ri-19_data-quality-and-drift.md
@@ -14,6 +14,22 @@ eu-ai-act_references:
   - c3-s2-a10  # III.S2.A10: Data and Data Governance
   - c3-s2-a9   # III.S2.A9: Risk Management System
   - c3-s2-a15  # III.S2.A15: Accuracy, Robustness and Cybersecurity
+csa-ciro-canada_references:
+  # Securities recordkeeping and data integrity
+  - csa-sn-11-348        # Identifies data quality as a key AI governance concern
+  - ni-31-103             # s. 11.5 (general records — accuracy/completeness), s. 11.6 (records access)
+  - ciro-idpc-rules       # Rule 3800 (recordkeeping) — accuracy and completeness of records, including AI-derived data
+  - ciro-acr-2026         # FinOps examination — verifying "AI is working as designed" implies data quality
+  # Outsourcing / technology governance
+  - ni-31-103cp           # CP Part 11 — outsourcing accountability extends to third-party AI data quality
+  - ciro-gn-2300-21-003   # Outsourcing Arrangements — SLAs and monitoring cover AI provider data quality
+  - osfi-b-13             # OSFI B-13 — technology risk management, data integrity through lifecycle (FRFIs)
+  # Model risk management benchmarks
+  - osfi-e-23-2027        # Data quality, model validation, ongoing monitoring, drift detection (FRFIs, 2027)
+  - qc-amf-ai-guideline   # Lifecycle risk management — data quality, hallucinations, drift (QC FIs, 2027)
+  - iosco-fr-02-2026      # Toolkit — model validation and ongoing monitoring across AI lifecycle
+  # Privacy accuracy obligation
+  - pipeda                # PIPEDA Principle 4.6 — accuracy of personal information used in AI models
 related_risks:
   - ri-4   # Hallucination and Inaccurate Outputs
   - ri-16  # Bias and Discrimination

--- a/docs/_risks/ri-1_information-leaked-to-hosted-model.md
+++ b/docs/_risks/ri-1_information-leaked-to-hosted-model.md
@@ -17,6 +17,23 @@ eu-ai-act_references:
   - c3-s2-a10  # III.S2.A10: Data and Data Governance
   - c3-s2-a13  # III.S2.A13: Transparency and Provision of Information to Deployers
   - c5-s2-a53  # V.S2.A53: Obligations for Providers of General-Purpose AI Models
+csa-ciro-canada_references:
+  # Securities cyber and outsourcing
+  - csa-sn-11-348        # Explicitly flags privacy law implications of inputting client info into third-party AI
+  - csa-sn-11-326         # CSA Cyber Security (2013) — first cross-sectoral cyber guidance
+  - csa-sn-11-332         # CSA Cyber Security (2016) — follow-up cyber risk expectations
+  - csa-sn-33-321         # CSA Cyber Security and Social Media (2017) — IFMs, PMs, EMDs
+  - ni-31-103             # s. 11.1 (compliance system), s. 11.5 (records confidentiality), outsourcing
+  - ni-31-103cp           # CP Part 11 — outsourcing accountability for client info transferred to AI provider
+  - ciro-idpc-rules       # Rule 3800 (recordkeeping/confidentiality) — client info in AI-enabled workflows
+  - ciro-gn-2300-21-003   # Outsourcing Arrangements — confidentiality, cross-border due diligence
+  # Tier 3 benchmarks
+  - osfi-b-13             # OSFI B-13 Technology and Cyber Risk Management — data confidentiality (FRFIs)
+  - iosco-fr-02-2026      # Toolkit Section 3.2 — third-party data security considerations
+  # Tier 4 — primary privacy framework
+  - pipeda                # PIPEDA 4.1.3 (third-party accountability), 4.7 (safeguards), s. 10.1 (breach notification)
+  - qc-p39-s12-1          # Quebec Law 25 s. 12.1 — ADM transparency includes disclosing personal info used
+  - qc-p39-s3-3-s17       # Quebec Law 25 ss. 3.3, 17 — PIAs for AI processing, cross-border adequacy
 related_risks:
   - ri-2   # Information Leaked to Vector Store
   - ri-23  # Intellectual Property and Copyright

--- a/docs/_risks/ri-20_reputational-risk.md
+++ b/docs/_risks/ri-20_reputational-risk.md
@@ -14,6 +14,19 @@ eu-ai-act_references:
   - c2-a5      # II.A5 Prohibited AI Practices
   - c3-s2-a9   # III.S2.A9: Risk Management System
   - c3-s2-a14  # III.S2.A14: Human Oversight
+csa-ciro-canada_references:
+  # Misleading AI claims / AI washing
+  - csa-sn-11-348        # Identifies misleading AI claims as a key risk; flags AI washing
+  - ni-81-102             # Part 15 sales communications — AI washing explicitly flagged by SN 11-348
+  - ni-31-103             # s. 13.4 — fair, clear, accurate client-facing communications
+  # Conflicts that drive reputational harm
+  - csa-ciro-sn-31-363   # Conflicts of interest review — undisclosed AI conflicts produce reputational harm
+  - ni-81-107             # IRC referral — undisclosed/unresolved AI conflicts create reputational exposure
+  # Operational failure as reputational risk
+  - ciro-acr-2026         # FinOps examination — operational AI failures examined
+  - osfi-e-23-2027        # E-23 explicitly frames bias/unfair outputs as reputational risk (FRFIs, 2027)
+  # International benchmark
+  - iosco-fr-02-2026      # Toolkit — reputational risk across the AI lifecycle
 related_risks:
   - ri-10  # Prompt Injection
   - ri-16  # Bias and Discrimination

--- a/docs/_risks/ri-22_regulatory-compliance-and-oversight.md
+++ b/docs/_risks/ri-22_regulatory-compliance-and-oversight.md
@@ -17,6 +17,34 @@ eu-ai-act_references:
   - c3-s3-a16  # III.S3.A16: Obligations of Providers of High-Risk AI Systems
   - c3-s3-a21  # III.S3.A21: Cooperation with Competent Authorities
   - c3-s3-a27  # III.S3.A27: Fundamental Rights Impact Assessment for High-Risk AI Systems
+csa-ciro-canada_references:
+  # AI-specific guidance
+  - csa-sn-11-348        # CSA SN 11-348: AI in Capital Markets — interpretive anchor
+  - ciro-acr-2026         # CIRO 2026 Compliance Report — AI section, FinOps posture
+  # Registration / conduct / suitability
+  - ni-31-103             # s. 11.1 (compliance/outsourcing), s. 13.2–13.4 (KYC/KYP/suitability/conflicts)
+  - ni-31-103cp           # CP Part 11 — outsourcing framework: due diligence, accountability, registerable-vs-support
+  - csa-ciro-sn-31-363   # Joint CFR review — conflicts of interest
+  - csa-ciro-sn-31-368   # Joint CFR review — KYC/KYP/suitability
+  - csa-sn-31-342         # Online advice — AR must remain decision-maker; AI cannot substitute
+  - ni-33-109-f5          # Form 33-109F5 — material business change notification
+  # Investment funds
+  - ni-81-102             # s. 5.1(1)(c) fundamental change trigger; Part 15 sales communications; AI washing
+  - ni-81-107             # IRC referral for AI-related conflicts (proprietary models, vendor incentives)
+  - ni-81-106             # Material change reporting for AI adoption in fund operations
+  # CIRO rules and outsourcing
+  - ciro-idpc-rules       # Business conduct (3100–3600), recordkeeping (3800), supervision (3900)
+  - ciro-rules-phase-4    # Proposed Rules 3900/3907 — supervision of automated tasks
+  - ciro-gn-2300-21-003   # Outsourcing Arrangements — due diligence, SLAs, monitoring, exit
+  # Tier 3 benchmarks
+  - osfi-e-23-2027        # OSFI E-23 Model Risk Management (FRFIs, eff. 2027)
+  - osfi-b-10             # OSFI B-10 Third-Party Risk Management (FRFIs) — concentration risk
+  - qc-amf-ai-guideline   # AMF AI Guideline (QC-regulated FIs, eff. 2027)
+  - iosco-fr-02-2026      # IOSCO Supervisory Toolkit for AI in Capital Markets
+  # Tier 4 adjacent compliance obligations
+  - pipeda                # Privacy compliance for AI deployment — SN 11-348 flags outsourcing/privacy intersection
+  - qc-p39-s12-1          # Quebec Law 25 s. 12.1 — ADM transparency obligation
+  - qc-p39-s3-3-s17       # Quebec Law 25 ss. 3.3, 17 — mandatory PIAs, cross-border transfer adequacy
 related_risks:
   - ri-16  # Bias and Discrimination
   - ri-17  # Lack of Explainability

--- a/docs/_risks/ri-2_information-leaked-to-vector-store.md
+++ b/docs/_risks/ri-2_information-leaked-to-vector-store.md
@@ -18,6 +18,24 @@ eu-ai-act_references:
   - c3-s2-a10  # III.S2.A10: Data and Data Governance
   - c3-s2-a15  # III.S2.A15: Accuracy, Robustness and Cybersecurity
   - c3-s3-a16  # III.S3.A16: Obligations of Providers of High-Risk AI Systems
+csa-ciro-canada_references:
+  # Securities cyber and outsourcing
+  - csa-sn-11-348        # Privacy law implications for AI systems including embeddings/vector stores
+  - csa-sn-11-326         # CSA Cyber Security (2013)
+  - csa-sn-11-332         # CSA Cyber Security (2016)
+  - csa-sn-33-321         # CSA Cyber Security and Social Media (2017)
+  - ni-31-103             # s. 11.1 (compliance), s. 11.5 (records — including derived data)
+  - ni-31-103cp           # CP Part 11 — outsourcing accountability extends to derived data assets
+  - ciro-idpc-rules       # Rule 3800 — applies to derived data assets, not just source records
+  - ciro-gn-2300-21-003   # Outsourcing Arrangements — vector stores hosted by third parties
+  # Tier 3 benchmarks
+  - osfi-b-13             # Technology and cyber risk management — data confidentiality through lifecycle
+  - osfi-b-10             # Third-Party Risk Management — vector store hosting concentration and vendor oversight
+  - osfi-e-23-2027        # Model lifecycle includes derived artifacts (embeddings/vectors); validation and protection
+  - iosco-fr-02-2026      # Toolkit — third-party data security and model artifact considerations
+  # Tier 4 — primary privacy framework
+  - pipeda                # PIPEDA 4.5 (retention — embeddings persist), 4.7 (safeguards), s. 10.1 (breach)
+  - qc-p39-s3-3-s17       # Quebec Law 25 — PIAs for vector processing; cross-border adequacy
 related_risks:
   - ri-1   # Information Leaked To Hosted Model
   - ri-9   # Data Poisoning


### PR DESCRIPTION
## Summary

Follow-up to **#290** (`docs/_data/csa-ciro-canada.yml`). #290 contributed the Canadian regulatory reference *data*; this PR adds the *mappings* — `csa-ciro-canada_references:` front matter on 8 risk files — and wires the dataset into the risk/mitigation layouts. Addresses **#253** (Canadian Mappings).

**Please land #290 first.** Until #290 merges, the diff below will show the full 32-entry `csa-ciro-canada.yml` as new content; the moment #290 merges, GitHub recomputes the merge base and the diff cleans up automatically to "12 entries added on top of #290 + 8 risk files + 2 layouts."

## What's changed

- `docs/_data/csa-ciro-canada.yml`: **20 → 32 entries** (adds CIRO GN-2300-21-003, NI 81-102/106/107, CSA SN 31-342, AMF AI Guideline, OSFI B-10, and a new Tier 4 block of cross-cutting privacy/human-rights statutes; replaces the IOSCO CR/01/2025 consultation with its successor final report IOSCO FR/02/2026).
- `csa-ciro-canada_references:` added to **ri-1, ri-2, ri-16, ri-17, ri-18, ri-19, ri-20, ri-22**.
- `reference-card.html` include wired into `risk.html` and `mitigation.html` (no-op until front matter declares the key, per the existing `references.size > 0` guard).

## Relationship to the data PRs (no structural view taken)

The home for the Canadian reference data — this standalone `csa-ciro-canada.yml` (#290) or the consolidated `canada-regulations.yml` (#301) — is a project-shape decision I'm leaving to maintainers and the steering committee. To make sure that decision carries **no rework cost**, the same mapping content is offered against both foundations: this PR keys to #290's flat schema, and a parallel PR keys to #301's sub-keyed schema. The regulatory substance is identical; only the dataset keys differ. Whichever data PR lands, its mapping PR comes with it ready to merge and the other simply closes. Happy to rebase whichever way you prefer.

## Methodology

1. **Selective composition, not enumeration** — density varies by actual coverage (7 entries for ri-16, 21 for ri-22), not uniform padding.
2. **Text-reach test** — an instrument is mapped to a risk only where its *text* reaches that failure mode, never by analogy.
3. **NI 31-103 s. 13.3** — the "reasonable basis" (epistemic) prong is mapped to explainability (ri-17); the "suitable for the client" prong is *not* mapped to bias (ri-16), because bias is a population-level property s. 13.3 doesn't reach.
4. **AR remains decision-maker** — AI may assist but not substitute for registerable activity; the assist/substitute boundary is flagged as under active interpretation (SN 31-342 predates LLMs).
5. **Cross-border = governance burden, not a sovereignty mandate** (Quebec Law 25 ss. 3.3/17, PIPEDA 4.1.3, OSFI residency considerations).
6. **Composition from general instruments, with named gaps** (no horizontal Canadian AI statute; AIDA died with Bill C-27, January 2025).

**Tier 4 is an explicit RFC to maintainers:** is adjacent-statute inclusion (privacy/human-rights) acceptable inside a jurisdictional data file, or should those live in separate per-statute files? Admission criteria are encoded in the Tier 4 header.

Full per-risk composition tables (entries bucketed by legal force × scope × timing) and the "known omissions" list are in the framing notes accompanying this PR.

## Per-risk coverage

| Risk | Refs | Risk | Refs |
|---|---|---|---|
| ri-22 Regulatory Compliance | 21 | ri-19 Data Quality & Drift | 11 |
| ri-16 Bias & Discrimination | 7 | ri-20 Reputational Risk | 8 |
| ri-17 Lack of Explainability | 11 | ri-1 Info Leak → Hosted Model | 13 |
| ri-18 Model Overreach | 12 | ri-2 Info Leak → Vector Store | 14 |

## Test plan

- [x] `jekyll build` clean from `docs/`
- [x] YAML parses; 32 entries; every `csa-ciro-canada_references` value resolves (0 dangling)
- [x] all 8 risk pages render the "Canada (CSA / CIRO) Regulatory References" card

## DCO

All commits signed off.