### PR TITLE
docs(uk): add UK regulatory reference mappings

### DIFF
--- a/docs/_data/uk-regulations.yml
+++ b/docs/_data/uk-regulations.yml
@@ -1,0 +1,143 @@
+# UK financial-services regulatory references relevant to AI governance.
+# Curated for the AI Governance Framework risk catalogue; URLs verified against
+# canonical regulator / legislation sites on 2026-06-16.
+
+fca-ai-approach-2024:
+  title: FCA - AI and the FCA; our approach / AI Update (2024)
+  issuer: FCA
+  url: https://www.fca.org.uk/firms/innovation/ai-approach
+  status: Regulatory approach / supervisory context
+  scope: Cross-sector FCA-regulated financial services
+
+boe-fca-ai-survey-2024:
+  title: Bank of England and FCA - Artificial intelligence in UK financial services 2024
+  issuer: BoE/FCA
+  url: https://www.bankofengland.co.uk/report/2024/artificial-intelligence-in-uk-financial-services-2024
+  status: Supervisory research / market intelligence
+  scope: PRA- and FCA-regulated firms
+
+pra-ss1-23-mrm:
+  title: PRA SS1/23 - Model risk management principles for banks
+  issuer: PRA
+  url: https://www.bankofengland.co.uk/prudential-regulation/publication/2023/may/model-risk-management-principles-for-banks-ss
+  status: Supervisory statement
+  scope: UK banks, building societies and PRA-designated investment firms in scope of SS1/23
+
+pra-ai-mrm-roundtable-2025:
+  title: PRA - Model risk management roundtable on AI and ML technologies (2025)
+  issuer: PRA
+  url: https://www.bankofengland.co.uk/prudential-regulation/publication/2025/november/pra-holds-model-risk-management-roundtable-on-ai
+  status: Supervisory engagement / good-practice discussion
+  scope: PRA-regulated firms using AI and ML in the context of SS1/23
+
+fca-prin:
+  title: FCA Handbook PRIN - Principles for Businesses, including Consumer Duty Principle 12
+  issuer: FCA
+  url: https://www.handbook.fca.org.uk/handbook/PRIN/
+  status: Binding FCA rules
+  scope: FCA-authorised firms
+
+fca-prin-2a:
+  title: FCA Handbook PRIN 2A - The Consumer Duty
+  issuer: FCA
+  url: https://www.handbook.fca.org.uk/handbook/PRIN/2A/
+  status: Binding FCA rules and guidance
+  scope: Retail-market business within Consumer Duty scope
+
+fca-sysc:
+  title: FCA Handbook SYSC - Senior Management Arrangements, Systems and Controls
+  issuer: FCA
+  url: https://www.handbook.fca.org.uk/handbook/SYSC/
+  status: Binding FCA rules and guidance
+  scope: FCA-authorised firms, subject to module-specific application provisions
+
+fca-smcr:
+  title: FCA - Senior Managers and Certification Regime
+  issuer: FCA
+  url: https://www.fca.org.uk/firms/senior-managers-certification-regime
+  status: Accountability regime
+  scope: FCA solo-regulated firms and dual-regulated firms, as applicable
+
+fca-cobs-4:
+  title: FCA Handbook COBS 4 - Communicating with clients, including financial promotions
+  issuer: FCA
+  url: https://www.handbook.fca.org.uk/handbook/COBS/4/
+  status: Binding FCA rules and guidance
+  scope: Investment business communications and financial promotions
+
+fca-cobs-9:
+  title: FCA Handbook COBS 9 - Suitability, including basic advice
+  issuer: FCA
+  url: https://www.handbook.fca.org.uk/handbook/COBS/9/
+  status: Binding FCA rules and guidance
+  scope: Investment advice and portfolio management suitability
+
+fca-cobs-9a:
+  title: FCA Handbook COBS 9A - Suitability, including MiFID provisions
+  issuer: FCA
+  url: https://www.handbook.fca.org.uk/handbook/COBS/9A/
+  status: Binding FCA rules and guidance
+  scope: MiFID investment advice and portfolio management suitability
+
+fca-mifidpru:
+  title: FCA Handbook MIFIDPRU - Prudential sourcebook for MiFID investment firms
+  issuer: FCA
+  url: https://www.handbook.fca.org.uk/handbook/MIFIDPRU/
+  status: Binding FCA rules and guidance
+  scope: FCA investment firms within IFPR/MIFIDPRU scope
+
+fca-fg16-5-cloud:
+  title: FCA FG16/5 - Guidance for firms outsourcing to the cloud and other third-party IT services
+  issuer: FCA
+  url: https://www.fca.org.uk/publication/finalised-guidance/fg16-5.pdf
+  status: Finalised guidance
+  scope: FCA-regulated firms using cloud and third-party IT services
+
+pra-ss2-21-outsourcing:
+  title: PRA SS2/21 - Outsourcing and third party risk management
+  issuer: PRA
+  url: https://www.bankofengland.co.uk/prudential-regulation/publication/2021/march/outsourcing-and-third-party-risk-management-ss
+  status: Supervisory statement
+  scope: PRA-regulated banks, building societies, PRA-designated investment firms and insurers
+
+boe-fca-pra-critical-third-parties-2024:
+  title: Bank of England, PRA and FCA - Operational resilience; critical third parties to the UK financial sector (2024 final policy)
+  issuer: BoE/PRA/FCA
+  url: https://www.bankofengland.co.uk/prudential-regulation/publication/2024/november/operational-resilience-critical-third-parties-uk-financial-sector-policy-statement
+  status: Final policy / rules for designated critical third parties
+  scope: Designated critical third parties and firms relying on systemic third-party services
+
+uk-gdpr-dpa-2018:
+  title: UK GDPR and Data Protection Act 2018 - data protection principles, special category data and automated decision-making
+  issuer: UK Parliament / ICO
+  url: https://ico.org.uk/for-organisations/uk-gdpr-guidance-and-resources/data-protection-principles/a-guide-to-the-data-protection-principles/
+  status: Binding law and regulator guidance
+  scope: Personal data processing in the UK
+
+ico-ai-data-protection-toolkit:
+  title: ICO - AI and data protection risk toolkit
+  issuer: ICO
+  url: https://ico.org.uk/for-organisations/uk-gdpr-guidance-and-resources/artificial-intelligence/guidance-on-ai-and-data-protection/ai-and-data-protection-risk-toolkit/
+  status: Regulator toolkit / guidance
+  scope: Organisations designing, procuring or deploying AI that processes personal data
+
+ico-guidance-ai-data-protection:
+  title: ICO - Guidance on AI and data protection
+  issuer: ICO
+  url: https://ico.org.uk/for-organisations/uk-gdpr-guidance-and-resources/artificial-intelligence/guidance-on-ai-and-data-protection/
+  status: Regulator guidance
+  scope: AI systems processing personal data
+
+equality-act-2010:
+  title: Equality Act 2010 - protected characteristics and services discrimination prohibitions
+  issuer: UK Parliament
+  url: https://www.legislation.gov.uk/ukpga/2010/15/contents
+  status: Binding law
+  scope: Employment, services and public functions in Great Britain
+
+consumer-credit-act-1974:
+  title: Consumer Credit Act 1974 - regulated credit and consumer protections
+  issuer: UK Parliament
+  url: https://www.legislation.gov.uk/ukpga/1974/39/contents
+  status: Binding law
+  scope: Regulated consumer credit and hire

--- a/docs/_layouts/mitigation.html
+++ b/docs/_layouts/mitigation.html
@@ -109,6 +109,11 @@ layout: default
                 heading="ISO 42001 References" %}
 
             {% include reference-card.html
+                references=page.uk-regulations_references
+                dataset="uk-regulations"
+                heading="UK Regulatory References" %}
+
+            {% include reference-card.html
                 references=page.nist-sp-800-53r5_references
                 dataset="nist-sp-800-53r5"
                 heading="NIST SP 800-53r5 References" %}

--- a/docs/_layouts/risk.html
+++ b/docs/_layouts/risk.html
@@ -109,6 +109,11 @@ layout: default
                 heading="EU AI Act References" %}
 
             {% include reference-card.html
+                references=page.uk-regulations_references
+                dataset="uk-regulations"
+                heading="UK Regulatory References" %}
+
+            {% include reference-card.html
                 references=page.nist-sp-800-53r5_references
                 dataset="nist-sp-800-53r5"
                 heading="NIST SP 800-53r5 References" %}

--- a/docs/_risks/ri-16_bias-and-discrimination.md
+++ b/docs/_risks/ri-16_bias-and-discrimination.md
@@ -16,6 +16,15 @@ eu-ai-act_references:
   - c3-s2-a10  # III.S2.A10: Data and Data Governance
   - c3-s2-a14  # III.S2.A14: Human Oversight
   - c3-s3-a27  # III.S3.A27: Fundamental Rights Impact Assessment for High-Risk AI Systems
+uk-regulations_references:
+  - fca-ai-approach-2024
+  - fca-prin
+  - fca-prin-2a
+  - uk-gdpr-dpa-2018
+  - ico-guidance-ai-data-protection
+  - ico-ai-data-protection-toolkit
+  - equality-act-2010
+  - consumer-credit-act-1974
 related_risks:
   - ri-19  # Data Quality and Drift
   - ri-22  # Regulatory Compliance and Oversight

--- a/docs/_risks/ri-17_lack-of-explainability.md
+++ b/docs/_risks/ri-17_lack-of-explainability.md
@@ -14,6 +14,15 @@ eu-ai-act_references:
   - c3-s2-a14  # III.S2.A14: Human Oversight
   - c4-a50     # IV.A50 Transparency Obligations for Providers and Deployers of Certain AI Systems
   - c9-s4-a86  # IX.S4.A86: Right to Explanation of Individual Decision-Making
+uk-regulations_references:
+  - fca-ai-approach-2024
+  - fca-prin-2a
+  - fca-cobs-9
+  - fca-cobs-9a
+  - pra-ss1-23-mrm
+  - uk-gdpr-dpa-2018
+  - ico-guidance-ai-data-protection
+  - ico-ai-data-protection-toolkit
 related_risks:
   - ri-22  # Regulatory Compliance and Oversight
   - ri-16  # Bias and Discrimination

--- a/docs/_risks/ri-18_model-overreach-expanded-use.md
+++ b/docs/_risks/ri-18_model-overreach-expanded-use.md
@@ -14,6 +14,16 @@ eu-ai-act_references:
   - c3-s1-a6   # III.S1.A6: Classification Rules for High-Risk AI Systems
   - c3-s2-a14  # III.S2.A14: Human Oversight
   - c3-s3-a26  # III.S3.A26: Obligations of Deployers of High-Risk AI Systems
+uk-regulations_references:
+  - fca-ai-approach-2024
+  - fca-prin
+  - fca-prin-2a
+  - fca-sysc
+  - fca-smcr
+  - fca-cobs-9
+  - fca-cobs-9a
+  - pra-ss1-23-mrm
+  - pra-ai-mrm-roundtable-2025
 related_risks:
   - ri-10  # Prompt Injection
   - ri-17  # Lack of Explainability

--- a/docs/_risks/ri-19_data-quality-and-drift.md
+++ b/docs/_risks/ri-19_data-quality-and-drift.md
@@ -14,6 +14,16 @@ eu-ai-act_references:
   - c3-s2-a10  # III.S2.A10: Data and Data Governance
   - c3-s2-a9   # III.S2.A9: Risk Management System
   - c3-s2-a15  # III.S2.A15: Accuracy, Robustness and Cybersecurity
+uk-regulations_references:
+  - fca-ai-approach-2024
+  - boe-fca-ai-survey-2024
+  - fca-prin-2a
+  - fca-sysc
+  - pra-ss1-23-mrm
+  - pra-ai-mrm-roundtable-2025
+  - uk-gdpr-dpa-2018
+  - ico-guidance-ai-data-protection
+  - ico-ai-data-protection-toolkit
 related_risks:
   - ri-4   # Hallucination and Inaccurate Outputs
   - ri-16  # Bias and Discrimination

--- a/docs/_risks/ri-1_information-leaked-to-hosted-model.md
+++ b/docs/_risks/ri-1_information-leaked-to-hosted-model.md
@@ -17,6 +17,14 @@ eu-ai-act_references:
   - c3-s2-a10  # III.S2.A10: Data and Data Governance
   - c3-s2-a13  # III.S2.A13: Transparency and Provision of Information to Deployers
   - c5-s2-a53  # V.S2.A53: Obligations for Providers of General-Purpose AI Models
+uk-regulations_references:
+  - fca-sysc
+  - fca-fg16-5-cloud
+  - pra-ss2-21-outsourcing
+  - uk-gdpr-dpa-2018
+  - ico-guidance-ai-data-protection
+  - ico-ai-data-protection-toolkit
+  - boe-fca-pra-critical-third-parties-2024
 related_risks:
   - ri-2   # Information Leaked to Vector Store
   - ri-23  # Intellectual Property and Copyright

--- a/docs/_risks/ri-20_reputational-risk.md
+++ b/docs/_risks/ri-20_reputational-risk.md
@@ -14,6 +14,15 @@ eu-ai-act_references:
   - c2-a5      # II.A5 Prohibited AI Practices
   - c3-s2-a9   # III.S2.A9: Risk Management System
   - c3-s2-a14  # III.S2.A14: Human Oversight
+uk-regulations_references:
+  - fca-ai-approach-2024
+  - boe-fca-ai-survey-2024
+  - fca-prin
+  - fca-prin-2a
+  - fca-cobs-4
+  - fca-smcr
+  - equality-act-2010
+  - uk-gdpr-dpa-2018
 related_risks:
   - ri-10  # Prompt Injection
   - ri-16  # Bias and Discrimination

--- a/docs/_risks/ri-22_regulatory-compliance-and-oversight.md
+++ b/docs/_risks/ri-22_regulatory-compliance-and-oversight.md
@@ -17,6 +17,27 @@ eu-ai-act_references:
   - c3-s3-a16  # III.S3.A16: Obligations of Providers of High-Risk AI Systems
   - c3-s3-a21  # III.S3.A21: Cooperation with Competent Authorities
   - c3-s3-a27  # III.S3.A27: Fundamental Rights Impact Assessment for High-Risk AI Systems
+uk-regulations_references:
+  - fca-ai-approach-2024
+  - boe-fca-ai-survey-2024
+  - pra-ss1-23-mrm
+  - pra-ai-mrm-roundtable-2025
+  - fca-prin
+  - fca-prin-2a
+  - fca-sysc
+  - fca-smcr
+  - fca-cobs-4
+  - fca-cobs-9
+  - fca-cobs-9a
+  - fca-mifidpru
+  - fca-fg16-5-cloud
+  - pra-ss2-21-outsourcing
+  - boe-fca-pra-critical-third-parties-2024
+  - uk-gdpr-dpa-2018
+  - ico-guidance-ai-data-protection
+  - ico-ai-data-protection-toolkit
+  - equality-act-2010
+  - consumer-credit-act-1974
 related_risks:
   - ri-16  # Bias and Discrimination
   - ri-17  # Lack of Explainability

--- a/docs/_risks/ri-2_information-leaked-to-vector-store.md
+++ b/docs/_risks/ri-2_information-leaked-to-vector-store.md
@@ -18,6 +18,14 @@ eu-ai-act_references:
   - c3-s2-a10  # III.S2.A10: Data and Data Governance
   - c3-s2-a15  # III.S2.A15: Accuracy, Robustness and Cybersecurity
   - c3-s3-a16  # III.S3.A16: Obligations of Providers of High-Risk AI Systems
+uk-regulations_references:
+  - fca-sysc
+  - fca-fg16-5-cloud
+  - pra-ss2-21-outsourcing
+  - uk-gdpr-dpa-2018
+  - ico-guidance-ai-data-protection
+  - ico-ai-data-protection-toolkit
+  - boe-fca-pra-critical-third-parties-2024
 related_risks:
   - ri-1   # Information Leaked To Hosted Model
   - ri-9   # Data Poisoning


### PR DESCRIPTION
### Motivation

- Provide a UK-specific counterpart to existing jurisdictional mappings so the risk catalogue can surface UK financial- and data-regulatory guidance alongside EU references.  
- Make it straightforward for maintainers to review and discuss UK regulator guidance in the same pattern as other jurisdiction datasets.  

### Description

- Adds `docs/_data/uk-regulations.yml` containing 20 curated UK regulatory references (FCA/PRA/BoE/ICO, UK GDPR, Equality Act, Consumer Credit Act, outsourcing/third-party and model-risk guidance).  
- Adds `uk-regulations_references:` front-matter arrays to eight risk pages (`ri-1`, `ri-2`, `ri-16`, `ri-17`, `ri-18`, `ri-19`, `ri-20`, `ri-22`) mapping relevant UK instruments to those failure modes.  
- Wires the existing `reference-card.html` include into `docs/_layouts/risk.html` and `docs/_layouts/mitigation.html` to render `uk-regulations` alongside other datasets without new rendering logic.  
- Follows the existing Canada PR pattern by keeping the dataset as a single jurisdiction file and using `status`/`scope` metadata for each reference.  

### Testing

- Ran `bash ./scripts/lint-check`, which succeeded.  
- Performed a YAML/lookup validation with a Python check that reported `20 UK references; 76 risk mappings; 0 dangling references`.  
- Attempted `cd docs && bundle exec jekyll build` but it could not run in this environment because there is no `Gemfile` or `.bundle/` directory.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a31390bd9008328bb431c923768996d)