### PR TITLE
ADD: Loan approval use case

### DIFF
--- a/docs/_data/ai_deployment_model.yml
+++ b/docs/_data/ai_deployment_model.yml
@@ -36,10 +36,8 @@ ai_deployment_model_taxonomy:
           description: >
             Distributed learning across multiple data sources without centralizing data.
 
-  # Workflows orchestrate LLMs and tools through predefined code paths; agents
-  # dynamically direct their own processes and tool usage. The two are kept as
-  # separate dimensions because they generally carry different risk ratings.
-  # See https://www.anthropic.com/engineering/building-effective-agents
+  # Workflow patterns and agent patterns kept separate.
+  # Inspired by https://www.anthropic.com/engineering/building-effective-agents
   - workflow_pattern:
       - Prompt_Chaining:
           description: >

--- a/docs/_data/ai_deployment_model.yml
+++ b/docs/_data/ai_deployment_model.yml
@@ -36,19 +36,34 @@ ai_deployment_model_taxonomy:
           description: >
             Distributed learning across multiple data sources without centralizing data.
 
-  - agentic_workflow_pattern:
-      - Sequential:
+  # Workflows orchestrate LLMs and tools through predefined code paths; agents
+  # dynamically direct their own processes and tool usage. The two are kept as
+  # separate dimensions because they generally carry different risk ratings.
+  # See https://www.anthropic.com/engineering/building-effective-agents
+  - workflow_pattern:
+      - Prompt_Chaining:
           description: >
-            Agents or AI-enabled steps execute in a fixed sequence where each step depends on the output of the previous step.
-      - Parallel:
+            LLM-enabled steps execute in a fixed sequence where each step processes the output of the previous one, with optional programmatic gates between steps. Control flow is defined in code.
+      - Routing:
           description: >
-            Multiple agents or AI-enabled tasks execute concurrently and their outputs are later aggregated or reconciled.
-      - Hierarchical:
+            An input is classified and directed to a specialized follow-up task or handler, allowing prompts and tools to be optimized per category.
+      - Parallelization:
           description: >
-            A supervisor, planner, or orchestrator agent decomposes work, delegates tasks to specialist agents, and consolidates results.
-      - Hybrid_Hierarchical_Parallel:
+            Multiple LLM-enabled tasks run concurrently and their outputs are aggregated, either by sectioning a task into independent subtasks or by voting across runs for higher confidence.
+      - Orchestrator_Workers:
           description: >
-            A multi-agent workflow combining hierarchical orchestration with parallel specialist-agent execution.
+            A central LLM decomposes a task, delegates subtasks to worker LLMs, and synthesizes their results, while the orchestration logic remains in predefined code paths.
+      - Evaluator_Optimizer:
+          description: >
+            One LLM generates a response while another evaluates it against defined criteria and provides feedback in an iterative refinement loop.
+
+  - agent_pattern:
+      - Autonomous_Agent:
+          description: >
+            A single LLM dynamically directs its own processes and tool usage in a loop, planning and acting on environmental feedback until a stopping condition is met.
+      - Multi_Agent:
+          description: >
+            Multiple autonomous agents coordinate to accomplish a task, including agent-to-agent delegation and communication, where control flow emerges from agent decisions rather than predefined code.
 
   - deployment_type:
       - On_Premises:

--- a/docs/_data/ai_deployment_model.yml
+++ b/docs/_data/ai_deployment_model.yml
@@ -36,6 +36,20 @@ ai_deployment_model_taxonomy:
           description: >
             Distributed learning across multiple data sources without centralizing data.
 
+  - agentic_workflow_pattern:
+      - Sequential:
+          description: >
+            Agents or AI-enabled steps execute in a fixed sequence where each step depends on the output of the previous step.
+      - Parallel:
+          description: >
+            Multiple agents or AI-enabled tasks execute concurrently and their outputs are later aggregated or reconciled.
+      - Hierarchical:
+          description: >
+            A supervisor, planner, or orchestrator agent decomposes work, delegates tasks to specialist agents, and consolidates results.
+      - Hybrid_Hierarchical_Parallel:
+          description: >
+            A multi-agent workflow combining hierarchical orchestration with parallel specialist-agent execution.
+
   - deployment_type:
       - On_Premises:
           description: >

--- a/docs/_data/ai_use_cases.yml
+++ b/docs/_data/ai_use_cases.yml
@@ -18,6 +18,7 @@ AI_use_cases:
       - Credit_Risk_and_Scoring:
           - Alternative_Data_Credit_Models
           - Continuous_Credit_Monitoring
+          - Loan_Approval_and_Underwriting
       - Regulatory_Compliance_RegTech:
           - AML_Surveillance_and_Sanctions_Screening
           - Transaction_Monitoring

--- a/docs/_usecases/uc-3_loan-approval.md
+++ b/docs/_usecases/uc-3_loan-approval.md
@@ -89,7 +89,7 @@ Loan approval is document-heavy, manually intensive, and sensitive to inconsiste
 
 - **Faster Turnaround**: Automates document extraction, validation, risk scoring, decision routing, and agreement generation.
 - **Operational Efficiency**: Reduces manual effort across intake, fraud review, credit assessment, and document preparation.
-- **Consistent Decisioning**: Applies standardized underwriting thresholds and risk policies across applications.
+- **Consistent Policy Enforcement**: Deterministic decision logic applies standardized underwriting thresholds and risk policies uniformly across applications. AI agent outputs are probabilistic and are not guaranteed to be repeatable, so consistency is enforced by the deterministic policy gates rather than by the AI agents themselves.
 - **Improved Fraud Detection**: Flags suspicious patterns early in the workflow.
 - **Risk-Based Pricing**: Dynamically adjusts pricing based on credit risk, market data, and policy constraints.
 - **Auditability**: Produces traceable decision records linking application data, agent outputs, policy rules, human interventions, and final outcomes.
@@ -118,7 +118,7 @@ Because the workflow may involve multiple specialist agents and external APIs, d
 
 **Hallucination and Inaccurate Outputs:** Document intelligence and credit risk agents may extract incorrect values, fabricate missing information, or produce unsupported explanations. [Hallucination and Inaccurate Outputs](/risks/ri-4_hallucination-and-inaccurate-outputs/) should be mitigated with source citations, confidence thresholds, deterministic validation rules, and human review for low-confidence outputs.
 
-**Non-Deterministic Behaviour:** Multi-agent systems may produce different recommendations for similar applications if prompts, models, tools, or context vary. [Non-Deterministic Behaviour](/risks/ri-6_non-deterministic-behaviour/) should be managed through model version pinning, deterministic policy gates, workflow state capture, repeatability testing, and audit logs.
+**Non-Deterministic Behaviour:** Because LLMs sample from a distribution over possible outputs, and because of the added complexity of multi-agent interactions, multi-agent systems may produce different recommendations for similar applications even when prompts, models, tools, and context are held constant. [Non-Deterministic Behaviour](/risks/ri-6_non-deterministic-behaviour/) should be managed primarily through deterministic policy gates that bound AI outputs, supported by workflow state capture, repeatability testing, and audit logs. Model version pinning can reduce variability but offers limited durability, as hosted-model providers typically deprecate older versions with only a few months' notice; pipelines should therefore include regression and re-baselining testing whenever an underlying model changes.
 
 **System Alignment:** Agents may optimize for speed, approval rate, or pricing outcomes in ways that conflict with fair lending, risk appetite, or customer protection requirements. [Inadequate System Alignment](/risks/ri-14_inadequate-system-alignment/) should be mitigated by explicit policy constraints, supervisor-agent controls, human review thresholds, compliance gates, and model acceptance testing.
 

--- a/docs/_usecases/uc-3_loan-approval.md
+++ b/docs/_usecases/uc-3_loan-approval.md
@@ -1,0 +1,135 @@
+---
+sequence: 3
+title: "Loan Approval"
+layout: usecase
+doc-status: Draft
+category: Risk_and_Compliance
+
+description: "A multi-agent loan approval workflow that automates document intake, fraud detection, credit risk assessment, decisioning, pricing, human review, agreement generation, e-signature, and disbursement."
+end_user: "Loan officer, credit risk analyst, compliance officer, applicant"
+business_value: "Reduces loan approval cycle time while improving consistency, auditability, fraud detection, and risk-based pricing."
+
+related_risks:
+  - ri-1
+  - ri-4
+  - ri-6
+  - ri-14
+  - ri-17
+  - ri-19
+
+related_mitigations:
+  - mi-1
+  - mi-4
+  - mi-5
+  - mi-11
+
+data_classifications:
+  - name: Customer_PII_Data
+    data_types:
+      - Applicant identity and contact information
+      - Government-issued identity documents
+      - Employment and address history
+  - name: Sensitive_Financial_Data
+    data_types:
+      - Loan applications and supporting financial documents
+      - Income, liabilities, assets, bank statements, and credit score data
+      - AI-generated risk scores, pricing recommendations, and decision rationale
+  - name: Internal_Proprietary_Data
+    data_types:
+      - Lending policies and underwriting thresholds
+      - Fraud detection rules and typologies
+      - Pricing models and risk appetite parameters
+
+data_handling_aspects:
+  - Centralized
+  - Privacy_Preserving
+
+eu-ai-act_references:
+  - c3-s2-a10
+
+sr11-7_references:
+  - overview
+  - s2-dev
+  - s2-use
+  - s3
+  - s4-inventory
+
+regulatory_concerns:
+  - name: "ECOA / Fair Lending"
+    url: "https://www.consumerfinance.gov/compliance/compliance-resources/other-applicable-requirements/equal-credit-opportunity-act/"
+    jurisdiction: "US"
+  - name: "GDPR Article 22"
+    url: "https://gdpr-info.eu/art-22-gdpr/"
+    jurisdiction: "EU"
+
+further_reading:
+  - name: "Machine Learning in Credit Risk (Working Paper No. 1019)"
+    url: "https://www.bis.org/publ/work1019.htm"
+    source: "BIS"
+---
+
+## Description
+
+The Loan Approval use case automates and optimizes the end-to-end process for evaluating, approving, pricing, documenting, and disbursing loans. It combines workflow orchestration, specialist AI agents, deterministic decision logic, external data sources, and human review checkpoints.
+
+The system uses a hybrid hierarchical and parallel multi-agent workflow. A loan approval orchestrator coordinates specialist agents for document intelligence, fraud detection, compliance review, credit risk assessment, dynamic pricing, and document generation.
+
+### Key Functions
+
+- **Application Intake**: Accepts loan applications and supporting documents such as PDFs, images, identity evidence, bank statements, and financial records.
+- **Document Intelligence**: Extracts, validates, and normalizes applicant and financial data from uploaded documents.
+- **Automated Validation**: Detects missing, inconsistent, invalid, or low-confidence fields before routing the application to downstream checks.
+- **Fraud Detection**: Uses AI-based anomaly detection and identity/fraud signals to flag suspicious applications.
+- **Compliance Review**: Routes fraud-flagged or high-risk cases to compliance review with supporting evidence.
+- **Credit Risk Assessment**: Combines external credit score data, internal policy rules, and AI-generated default risk predictions.
+- **Decision Logic**: Uses deterministic thresholds and AI risk scores to auto-approve, reject, or route applications to manual review.
+- **Dynamic Pricing**: Adjusts loan pricing, including interest rate and terms, based on risk, policy, and market conditions.
+- **Human Review**: Provides loan officers with AI recommendations, extracted evidence, policy checks, and decision rationale.
+- **Document Generation and E-Signature**: Generates approved loan agreements and sends them for digital signature.
+- **Disbursement**: Initiates fund disbursement after approval, agreement generation, and signature completion.
+
+## Business Value
+
+Loan approval is document-heavy, manually intensive, and sensitive to inconsistent underwriting judgments. A multi-agent workflow can shorten the application-to-decision cycle while maintaining controlled human oversight for borderline, suspicious, or policy-sensitive cases.
+
+**Key Benefits:**
+
+- **Faster Turnaround**: Automates document extraction, validation, risk scoring, decision routing, and agreement generation.
+- **Operational Efficiency**: Reduces manual effort across intake, fraud review, credit assessment, and document preparation.
+- **Consistent Decisioning**: Applies standardized underwriting thresholds and risk policies across applications.
+- **Improved Fraud Detection**: Flags suspicious patterns early in the workflow.
+- **Risk-Based Pricing**: Dynamically adjusts pricing based on credit risk, market data, and policy constraints.
+- **Auditability**: Produces traceable decision records linking application data, agent outputs, policy rules, human interventions, and final outcomes.
+
+## End Users
+
+- **Primary**: Loan officers and credit risk analysts
+- **Secondary**: Compliance officers, fraud investigators, operations teams, and applicants
+- **Tertiary**: Model risk management, internal audit, and regulators reviewing decision controls
+
+## Data Sensitivity
+
+This use case processes **Customer PII Data** and **Sensitive Financial Data**, including identity documents, income data, liabilities, assets, credit scores, bank statements, and AI-generated underwriting recommendations.
+
+Because the workflow may involve multiple specialist agents and external APIs, data minimization, access controls, encryption, and strict data lineage are required. Each agent should receive only the data necessary for its task.
+
+## Regulatory Concerns
+
+- **EU AI Act**: Loan approval and creditworthiness assessment may qualify as a high-risk AI system.
+- **Fair Lending / ECOA**: Credit decisions must avoid prohibited discrimination and support adverse action explanations.
+- **GDPR Article 22**: Automated decisions affecting individuals require appropriate safeguards, transparency, and rights to contest or obtain human review.
+- **SR 11-7**: Model risk management applies to AI models used in credit risk, fraud detection, pricing, and decisioning.
+
+## AI Risks and Mitigations
+
+**Information Leakage:** The system processes sensitive identity, income, credit, and financial records. [Information Leaked To Hosted Model](/risks/ri-1_information-leaked-to-hosted-model/) is a material risk if document intelligence, fraud detection, credit scoring, or pricing agents use third-party hosted models.
+
+**Hallucination and Inaccurate Outputs:** Document intelligence and credit risk agents may extract incorrect values, fabricate missing information, or produce unsupported explanations. [Hallucination and Inaccurate Outputs](/risks/ri-4_hallucination-and-inaccurate-outputs/) should be mitigated with source citations, confidence thresholds, deterministic validation rules, and human review for low-confidence outputs.
+
+**Non-Deterministic Behaviour:** Multi-agent systems may produce different recommendations for similar applications if prompts, models, tools, or context vary. [Non-Deterministic Behaviour](/risks/ri-6_non-deterministic-behaviour/) should be managed through model version pinning, deterministic policy gates, workflow state capture, repeatability testing, and audit logs.
+
+**System Alignment:** Agents may optimize for speed, approval rate, or pricing outcomes in ways that conflict with fair lending, risk appetite, or customer protection requirements. [Inadequate System Alignment](/risks/ri-14_inadequate-system-alignment/) should be mitigated by explicit policy constraints, supervisor-agent controls, human review thresholds, compliance gates, and model acceptance testing.
+
+**Explainability:** Applicants, loan officers, compliance teams, and regulators need understandable reasons for approval, rejection, pricing, and manual review. [Lack of Explainability](/risks/ri-17_lack-of-explainability/) should be mitigated with decision audit trails, source traceability, adverse action reason mapping, and clear separation between AI recommendations and deterministic policy rules.
+
+**Data Quality and Drift:** Credit risk and fraud models depend on accurate, current, and representative data. [Data Quality and Drift](/risks/ri-19_data-quality-and-drift/) may arise from stale bureau data, changing macroeconomic conditions, document format changes, or evolving fraud typologies.

--- a/docs/_usecases/uc-3_loan-approval.md
+++ b/docs/_usecases/uc-3_loan-approval.md
@@ -47,13 +47,6 @@ data_handling_aspects:
 eu-ai-act_references:
   - c3-s2-a10
 
-sr11-7_references:
-  - overview
-  - s2-dev
-  - s2-use
-  - s3
-  - s4-inventory
-
 regulatory_concerns:
   - name: "ECOA / Fair Lending"
     url: "https://www.consumerfinance.gov/compliance/compliance-resources/other-applicable-requirements/equal-credit-opportunity-act/"
@@ -118,7 +111,6 @@ Because the workflow may involve multiple specialist agents and external APIs, d
 - **EU AI Act**: Loan approval and creditworthiness assessment may qualify as a high-risk AI system.
 - **Fair Lending / ECOA**: Credit decisions must avoid prohibited discrimination and support adverse action explanations.
 - **GDPR Article 22**: Automated decisions affecting individuals require appropriate safeguards, transparency, and rights to contest or obtain human review.
-- **SR 11-7**: Model risk management applies to AI models used in credit risk, fraud detection, pricing, and decisioning.
 
 ## AI Risks and Mitigations
 

--- a/docs/_usecases/uc-index.md
+++ b/docs/_usecases/uc-index.md
@@ -46,11 +46,13 @@ AI detects unusual transaction patterns and identity anomalies in real-time, red
 
 ### 2.2 Credit Risk & Scoring
 **How AI Helps:**  
-ML augments traditional credit scoring with alternative data sources such as transaction histories, social patterns, or mobile usage. Continuous learning models adapt as borrower behavior changes.  
-**Techniques:** Gradient-boosted models, explainable AI (SHAP), ensemble methods.  
+ML augments traditional credit scoring with alternative data sources such as transaction histories, social patterns, or mobile usage. Continuous learning models adapt as borrower behavior changes. Agentic workflows can also coordinate document intelligence, fraud detection, compliance review, credit risk assessment, pricing, human review, agreement generation, and disbursement for end-to-end loan approval.  
+**Techniques:** Gradient-boosted models, explainable AI (SHAP), ensemble methods, document intelligence, anomaly detection, multi-agent orchestration, human-in-the-loop decisioning.  
 **Benefits:**  
 - Better credit decisions for thin-file or new-to-credit customers.  
-- Dynamic credit line management.  
+- Faster and more consistent loan approval workflows.  
+- Dynamic credit line management and risk-based pricing.  
+- Improved auditability for approval, rejection, pricing, and manual review decisions.  
 
 ### 2.3 Regulatory Compliance (RegTech)
 **How AI Helps:**  


### PR DESCRIPTION
## Summary

Adds UC-3 Loan Approval as a new use case covering an end-to-end, AI-enhanced loan approval workflow.

## Changes

- Adds `docs/_usecases/uc-3_loan-approval.md`
- Adds `Loan_Approval_and_Underwriting` under `Credit_Risk_and_Scoring`
- Adds `agentic_workflow_pattern` to the deployment model taxonomy
- Updates the use case index with loan approval coverage

## Notes

The new taxonomy dimension captures sequential, parallel, hierarchical, and hybrid hierarchical/parallel multi-agent workflows.

Signed-off-by: Francesco Beltramini <97460655+d1gital-f@users.noreply.github.com>