### PR TITLE
Add UK regulatory references dataset and surface them in layouts; update risks to cite UK regs

### DIFF
--- a/docs/_data/uk-regulations.yml
+++ b/docs/_data/uk-regulations.yml
@@ -1,0 +1,143 @@
+# UK financial-services regulatory references relevant to AI governance.
+# Curated for the AI Governance Framework risk catalogue; URLs verified against
+# canonical regulator / legislation sites on 2026-06-16.
+
+fca-ai-approach-2024:
+  title: FCA - AI and the FCA; our approach / AI Update (2024)
+  issuer: FCA
+  url: https://www.fca.org.uk/firms/innovation/ai-approach
+  status: Regulatory approach / supervisory context
+  scope: Cross-sector FCA-regulated financial services
+
+boe-fca-ai-survey-2024:
+  title: Bank of England and FCA - Artificial intelligence in UK financial services 2024
+  issuer: BoE/FCA
+  url: https://www.bankofengland.co.uk/report/2024/artificial-intelligence-in-uk-financial-services-2024
+  status: Supervisory research / market intelligence
+  scope: PRA- and FCA-regulated firms
+
+pra-ss1-23-mrm:
+  title: PRA SS1/23 - Model risk management principles for banks
+  issuer: PRA
+  url: https://www.bankofengland.co.uk/prudential-regulation/publication/2023/may/model-risk-management-principles-for-banks-ss
+  status: Supervisory statement
+  scope: UK banks, building societies and PRA-designated investment firms in scope of SS1/23
+
+pra-ai-mrm-roundtable-2025:
+  title: PRA - Model risk management roundtable on AI and ML technologies (2025)
+  issuer: PRA
+  url: https://www.bankofengland.co.uk/prudential-regulation/publication/2025/november/pra-holds-model-risk-management-roundtable-on-ai
+  status: Supervisory engagement / good-practice discussion
+  scope: PRA-regulated firms using AI and ML in the context of SS1/23
+
+fca-prin:
+  title: FCA Handbook PRIN - Principles for Businesses, including Consumer Duty Principle 12
+  issuer: FCA
+  url: https://www.handbook.fca.org.uk/handbook/PRIN/
+  status: Binding FCA rules
+  scope: FCA-authorised firms
+
+fca-prin-2a:
+  title: FCA Handbook PRIN 2A - The Consumer Duty
+  issuer: FCA
+  url: https://www.handbook.fca.org.uk/handbook/PRIN/2A/
+  status: Binding FCA rules and guidance
+  scope: Retail-market business within Consumer Duty scope
+
+fca-sysc:
+  title: FCA Handbook SYSC - Senior Management Arrangements, Systems and Controls
+  issuer: FCA
+  url: https://www.handbook.fca.org.uk/handbook/SYSC/
+  status: Binding FCA rules and guidance
+  scope: FCA-authorised firms, subject to module-specific application provisions
+
+fca-smcr:
+  title: FCA - Senior Managers and Certification Regime
+  issuer: FCA
+  url: https://www.fca.org.uk/firms/senior-managers-certification-regime
+  status: Accountability regime
+  scope: FCA solo-regulated firms and dual-regulated firms, as applicable
+
+fca-cobs-4:
+  title: FCA Handbook COBS 4 - Communicating with clients, including financial promotions
+  issuer: FCA
+  url: https://www.handbook.fca.org.uk/handbook/COBS/4/
+  status: Binding FCA rules and guidance
+  scope: Investment business communications and financial promotions
+
+fca-cobs-9:
+  title: FCA Handbook COBS 9 - Suitability, including basic advice
+  issuer: FCA
+  url: https://www.handbook.fca.org.uk/handbook/COBS/9/
+  status: Binding FCA rules and guidance
+  scope: Investment advice and portfolio management suitability
+
+fca-cobs-9a:
+  title: FCA Handbook COBS 9A - Suitability, including MiFID provisions
+  issuer: FCA
+  url: https://www.handbook.fca.org.uk/handbook/COBS/9A/
+  status: Binding FCA rules and guidance
+  scope: MiFID investment advice and portfolio management suitability
+
+fca-mifidpru:
+  title: FCA Handbook MIFIDPRU - Prudential sourcebook for MiFID investment firms
+  issuer: FCA
+  url: https://www.handbook.fca.org.uk/handbook/MIFIDPRU/
+  status: Binding FCA rules and guidance
+  scope: FCA investment firms within IFPR/MIFIDPRU scope
+
+fca-fg16-5-cloud:
+  title: FCA FG16/5 - Guidance for firms outsourcing to the cloud and other third-party IT services
+  issuer: FCA
+  url: https://www.fca.org.uk/publication/finalised-guidance/fg16-5.pdf
+  status: Finalised guidance
+  scope: FCA-regulated firms using cloud and third-party IT services
+
+pra-ss2-21-outsourcing:
+  title: PRA SS2/21 - Outsourcing and third party risk management
+  issuer: PRA
+  url: https://www.bankofengland.co.uk/prudential-regulation/publication/2021/march/outsourcing-and-third-party-risk-management-ss
+  status: Supervisory statement
+  scope: PRA-regulated banks, building societies, PRA-designated investment firms and insurers
+
+boe-fca-pra-critical-third-parties-2024:
+  title: Bank of England, PRA and FCA - Operational resilience; critical third parties to the UK financial sector (2024 final policy)
+  issuer: BoE/PRA/FCA
+  url: https://www.bankofengland.co.uk/prudential-regulation/publication/2024/november/operational-resilience-critical-third-parties-uk-financial-sector-policy-statement
+  status: Final policy / rules for designated critical third parties
+  scope: Designated critical third parties and firms relying on systemic third-party services
+
+uk-gdpr-dpa-2018:
+  title: UK GDPR and Data Protection Act 2018 - data protection principles, special category data and automated decision-making
+  issuer: UK Parliament / ICO
+  url: https://ico.org.uk/for-organisations/uk-gdpr-guidance-and-resources/data-protection-principles/a-guide-to-the-data-protection-principles/
+  status: Binding law and regulator guidance
+  scope: Personal data processing in the UK
+
+ico-ai-data-protection-toolkit:
+  title: ICO - AI and data protection risk toolkit
+  issuer: ICO
+  url: https://ico.org.uk/for-organisations/uk-gdpr-guidance-and-resources/artificial-intelligence/guidance-on-ai-and-data-protection/ai-and-data-protection-risk-toolkit/
+  status: Regulator toolkit / guidance
+  scope: Organisations designing, procuring or deploying AI that processes personal data
+
+ico-guidance-ai-data-protection:
+  title: ICO - Guidance on AI and data protection
+  issuer: ICO
+  url: https://ico.org.uk/for-organisations/uk-gdpr-guidance-and-resources/artificial-intelligence/guidance-on-ai-and-data-protection/
+  status: Regulator guidance
+  scope: AI systems processing personal data
+
+equality-act-2010:
+  title: Equality Act 2010 - protected characteristics and services discrimination prohibitions
+  issuer: UK Parliament
+  url: https://www.legislation.gov.uk/ukpga/2010/15/contents
+  status: Binding law
+  scope: Employment, services and public functions in Great Britain
+
+consumer-credit-act-1974:
+  title: Consumer Credit Act 1974 - regulated credit and consumer protections
+  issuer: UK Parliament
+  url: https://www.legislation.gov.uk/ukpga/1974/39/contents
+  status: Binding law
+  scope: Regulated consumer credit and hire

--- a/docs/_layouts/mitigation.html
+++ b/docs/_layouts/mitigation.html
@@ -118,6 +118,11 @@ layout: default
                 dataset="nist-ai-600-1"
                 heading="NIST AI 600-1 References" %}
 
+            {% include reference-card.html
+                references=page.uk-regulations_references
+                dataset="uk-regulations"
+                heading="UK Regulatory References" %}
+
         </div>
     </div>
 </main>

--- a/docs/_layouts/risk.html
+++ b/docs/_layouts/risk.html
@@ -118,6 +118,11 @@ layout: default
                 dataset="nist-ai-600-1"
                 heading="NIST AI 600-1 References" %}
 
+            {% include reference-card.html
+                references=page.uk-regulations_references
+                dataset="uk-regulations"
+                heading="UK Regulatory References" %}
+
         </div>
     </div>
 </main>

--- a/docs/_risks/ri-16_bias-and-discrimination.md
+++ b/docs/_risks/ri-16_bias-and-discrimination.md
@@ -16,6 +16,17 @@ eu-ai-act_references:
   - c3-s2-a10  # III.S2.A10: Data and Data Governance
   - c3-s2-a14  # III.S2.A14: Human Oversight
   - c3-s3-a27  # III.S3.A27: Fundamental Rights Impact Assessment for High-Risk AI Systems
+uk-regulations_references:
+  # AI fairness and conduct expectations
+  - fca-ai-approach-2024 # FCA AI approach flags fairness, accountability and consumer outcomes
+  - fca-prin # Principles require integrity, skill/care/diligence and customers' interests
+  - fca-prin-2a # Consumer Duty requires good outcomes and avoidance of foreseeable harm
+  # Privacy, fairness and protected-characteristic law
+  - uk-gdpr-dpa-2018 # Fairness, special-category data and automated decision-making safeguards
+  - ico-guidance-ai-data-protection # ICO AI guidance addresses bias, fairness and statistical accuracy
+  - ico-ai-data-protection-toolkit # Toolkit includes bias/fairness checks for AI personal-data processing
+  - equality-act-2010 # Protected-characteristic discrimination baseline for services/employment
+  - consumer-credit-act-1974 # Consumer-credit protections relevant to AI credit decisions
 related_risks:
   - ri-19  # Data Quality and Drift
   - ri-22  # Regulatory Compliance and Oversight

--- a/docs/_risks/ri-17_lack-of-explainability.md
+++ b/docs/_risks/ri-17_lack-of-explainability.md
@@ -14,6 +14,17 @@ eu-ai-act_references:
   - c3-s2-a14  # III.S2.A14: Human Oversight
   - c4-a50     # IV.A50 Transparency Obligations for Providers and Deployers of Certain AI Systems
   - c9-s4-a86  # IX.S4.A86: Right to Explanation of Individual Decision-Making
+uk-regulations_references:
+  # Explainability for consumer outcomes and regulated advice
+  - fca-ai-approach-2024 # FCA AI approach stresses accountability and explainability expectations
+  - fca-prin-2a # Consumer Duty requires firms to evidence and explain good outcomes
+  - fca-cobs-9 # Suitability rules require a reasonable basis for personal recommendations
+  - fca-cobs-9a # MiFID suitability rules require explainable advice and portfolio decisions
+  # Model risk and automated decision-making transparency
+  - pra-ss1-23-mrm # Model documentation, validation and governance for in-scope models
+  - uk-gdpr-dpa-2018 # UK GDPR safeguards for solely automated decisions and meaningful information
+  - ico-guidance-ai-data-protection # ICO AI guidance covers explaining AI-assisted decisions
+  - ico-ai-data-protection-toolkit # Toolkit supports explainability and accountability assessment
 related_risks:
   - ri-22  # Regulatory Compliance and Oversight
   - ri-16  # Bias and Discrimination

--- a/docs/_risks/ri-18_model-overreach-expanded-use.md
+++ b/docs/_risks/ri-18_model-overreach-expanded-use.md
@@ -14,6 +14,18 @@ eu-ai-act_references:
   - c3-s1-a6   # III.S1.A6: Classification Rules for High-Risk AI Systems
   - c3-s2-a14  # III.S2.A14: Human Oversight
   - c3-s3-a26  # III.S3.A26: Obligations of Deployers of High-Risk AI Systems
+uk-regulations_references:
+  # Scope, accountability and consumer-outcome controls
+  - fca-ai-approach-2024 # FCA AI approach frames safe and responsible adoption expectations
+  - fca-prin # Principles require appropriate skill, care and management of business risks
+  - fca-prin-2a # Consumer Duty constrains expanded AI use causing foreseeable harm
+  - fca-sysc # SYSC governance controls apply to material system changes and oversight
+  - fca-smcr # SMCR allocates senior accountability for AI use beyond approved scope
+  # Regulated advice and model-risk boundaries
+  - fca-cobs-9 # Suitability rules limit unsupported use in personal recommendations
+  - fca-cobs-9a # MiFID suitability requirements constrain portfolio/advice automation scope
+  - pra-ss1-23-mrm # Model inventory, tiering and change controls address model-use drift
+  - pra-ai-mrm-roundtable-2025 # PRA AI/ML MRM discussion emphasises governance of AI model use
 related_risks:
   - ri-10  # Prompt Injection
   - ri-17  # Lack of Explainability

--- a/docs/_risks/ri-19_data-quality-and-drift.md
+++ b/docs/_risks/ri-19_data-quality-and-drift.md
@@ -14,6 +14,18 @@ eu-ai-act_references:
   - c3-s2-a10  # III.S2.A10: Data and Data Governance
   - c3-s2-a9   # III.S2.A9: Risk Management System
   - c3-s2-a15  # III.S2.A15: Accuracy, Robustness and Cybersecurity
+uk-regulations_references:
+  # AI adoption, operations and model lifecycle controls
+  - fca-ai-approach-2024 # FCA AI approach identifies data quality and model performance as governance concerns
+  - boe-fca-ai-survey-2024 # Sector survey evidence on AI use cases, controls and monitoring practices
+  - fca-prin-2a # Consumer Duty requires monitoring outcomes that can degrade through drift
+  - fca-sysc # Systems and controls require effective risk management and operational oversight
+  - pra-ss1-23-mrm # Model validation, monitoring and change controls address data/concept drift
+  - pra-ai-mrm-roundtable-2025 # PRA AI/ML MRM discussion focuses on lifecycle and monitoring challenges
+  # Data protection accuracy and AI data-quality controls
+  - uk-gdpr-dpa-2018 # Accuracy, fairness and data-minimisation principles for personal-data inputs
+  - ico-guidance-ai-data-protection # ICO AI guidance covers data quality, accuracy and statistical validity
+  - ico-ai-data-protection-toolkit # Toolkit supports data-quality and drift-related risk assessment
 related_risks:
   - ri-4   # Hallucination and Inaccurate Outputs
   - ri-16  # Bias and Discrimination

--- a/docs/_risks/ri-1_information-leaked-to-hosted-model.md
+++ b/docs/_risks/ri-1_information-leaked-to-hosted-model.md
@@ -17,6 +17,16 @@ eu-ai-act_references:
   - c3-s2-a10  # III.S2.A10: Data and Data Governance
   - c3-s2-a13  # III.S2.A13: Transparency and Provision of Information to Deployers
   - c5-s2-a53  # V.S2.A53: Obligations for Providers of General-Purpose AI Models
+uk-regulations_references:
+  # Systems, controls, outsourcing and third-party resilience
+  - fca-sysc # Systems and controls apply to confidential client data in AI workflows
+  - fca-fg16-5-cloud # Cloud/third-party IT guidance for hosted model providers
+  - pra-ss2-21-outsourcing # PRA outsourcing controls for material AI service providers
+  - boe-fca-pra-critical-third-parties-2024 # Systemic third-party services, including AI/cloud concentration
+  # Data protection and AI-specific privacy controls
+  - uk-gdpr-dpa-2018 # UK GDPR/DPA safeguards for personal data sent to hosted models
+  - ico-guidance-ai-data-protection # ICO AI guidance on controller accountability and security
+  - ico-ai-data-protection-toolkit # Toolkit prompts risk assessment of data leakage in AI systems
 related_risks:
   - ri-2   # Information Leaked to Vector Store
   - ri-23  # Intellectual Property and Copyright

--- a/docs/_risks/ri-20_reputational-risk.md
+++ b/docs/_risks/ri-20_reputational-risk.md
@@ -14,6 +14,17 @@ eu-ai-act_references:
   - c2-a5      # II.A5 Prohibited AI Practices
   - c3-s2-a9   # III.S2.A9: Risk Management System
   - c3-s2-a14  # III.S2.A14: Human Oversight
+uk-regulations_references:
+  # AI governance, conduct and public-claim risk
+  - fca-ai-approach-2024 # FCA AI approach includes responsible innovation and consumer trust expectations
+  - boe-fca-ai-survey-2024 # Survey context on adoption levels and risk controls informs reputational exposure
+  - fca-prin # Principles set high-level conduct expectations underpinning trust
+  - fca-prin-2a # Consumer Duty failures can create significant public and supervisory scrutiny
+  - fca-cobs-4 # Financial promotions must be fair, clear and not misleading, including AI claims
+  - fca-smcr # Senior accountability can attach to visible AI governance failures
+  # Adjacent rights and privacy harms that amplify reputation damage
+  - equality-act-2010 # Discriminatory AI outcomes create legal and reputational exposure
+  - uk-gdpr-dpa-2018 # Personal-data misuse or breaches trigger notification and trust impacts
 related_risks:
   - ri-10  # Prompt Injection
   - ri-16  # Bias and Discrimination

--- a/docs/_risks/ri-22_regulatory-compliance-and-oversight.md
+++ b/docs/_risks/ri-22_regulatory-compliance-and-oversight.md
@@ -17,6 +17,31 @@ eu-ai-act_references:
   - c3-s3-a16  # III.S3.A16: Obligations of Providers of High-Risk AI Systems
   - c3-s3-a21  # III.S3.A21: Cooperation with Competent Authorities
   - c3-s3-a27  # III.S3.A27: Fundamental Rights Impact Assessment for High-Risk AI Systems
+uk-regulations_references:
+  # AI-specific supervisory materials and market intelligence
+  - fca-ai-approach-2024 # FCA's AI approach is the UK conduct-regulator interpretive anchor
+  - boe-fca-ai-survey-2024 # Joint survey frames current AI use, controls and supervisory concerns
+  - pra-ai-mrm-roundtable-2025 # PRA AI/ML MRM engagement informs supervisory discussion topics
+  # Model risk, governance, accountability and conduct
+  - pra-ss1-23-mrm # Model risk management principles for in-scope banks and PRA-designated firms
+  - fca-prin # Principles for Businesses apply regardless of AI or human delivery channel
+  - fca-prin-2a # Consumer Duty is central for retail AI outcomes and foreseeable harm
+  - fca-sysc # Systems and controls sourcebook anchors AI governance and operational oversight
+  - fca-smcr # Senior accountability and certification regime for AI control ownership
+  # Advice, communications, prudential and outsourcing controls
+  - fca-cobs-4 # Financial promotions and client communications, including AI-generated content
+  - fca-cobs-9 # Suitability requirements for non-MiFID personal recommendations
+  - fca-cobs-9a # MiFID suitability requirements for advice and portfolio management
+  - fca-mifidpru # Prudential governance context for FCA investment firms
+  - fca-fg16-5-cloud # Cloud and third-party IT guidance for AI service-provider arrangements
+  - pra-ss2-21-outsourcing # PRA outsourcing and third-party risk management expectations
+  - boe-fca-pra-critical-third-parties-2024 # Critical third-party policy for systemic service dependencies
+  # Cross-cutting data, equality and consumer-credit obligations
+  - uk-gdpr-dpa-2018 # Privacy, transparency and automated-decision safeguards
+  - ico-guidance-ai-data-protection # ICO AI guidance for personal-data processing in AI systems
+  - ico-ai-data-protection-toolkit # ICO toolkit for AI data-protection risk assessment
+  - equality-act-2010 # Equality and non-discrimination obligations for services and employment
+  - consumer-credit-act-1974 # Consumer-credit law relevant to AI-assisted lending decisions
 related_risks:
   - ri-16  # Bias and Discrimination
   - ri-17  # Lack of Explainability

--- a/docs/_risks/ri-2_information-leaked-to-vector-store.md
+++ b/docs/_risks/ri-2_information-leaked-to-vector-store.md
@@ -18,6 +18,16 @@ eu-ai-act_references:
   - c3-s2-a10  # III.S2.A10: Data and Data Governance
   - c3-s2-a15  # III.S2.A15: Accuracy, Robustness and Cybersecurity
   - c3-s3-a16  # III.S3.A16: Obligations of Providers of High-Risk AI Systems
+uk-regulations_references:
+  # Systems, controls, outsourcing and third-party resilience
+  - fca-sysc # Systems and controls cover derived records, embeddings and retrieval stores
+  - fca-fg16-5-cloud # Cloud/third-party IT guidance for hosted vector databases
+  - pra-ss2-21-outsourcing # PRA outsourcing expectations for material data stores
+  - boe-fca-pra-critical-third-parties-2024 # Critical third-party dependency risk for hosted retrieval infrastructure
+  # Data protection and AI-specific privacy controls
+  - uk-gdpr-dpa-2018 # UK GDPR/DPA applies where embeddings or metadata include personal data
+  - ico-guidance-ai-data-protection # ICO AI guidance covers security, minimisation and reuse controls
+  - ico-ai-data-protection-toolkit # Toolkit supports AI privacy risk assessment for retrieval stores
 related_risks:
   - ri-1   # Information Leaked To Hosted Model
   - ri-9   # Data Poisoning


### PR DESCRIPTION
### Motivation

- Provide a curated dataset of UK financial-services regulatory references relevant to AI governance so risks and mitigations can cite canonical UK rules and guidance.  
- Surface those references in the site layouts so pages can display UK-specific regulatory guidance alongside existing standards.  
- Link common financial-services AI risks to relevant UK law, regulator guidance and supervisory statements to improve regulatory mapping in the risk catalogue.

### Description

- Added a new data file `docs/_data/uk-regulations.yml` containing curated UK regulator and legislation entries (FCA, PRA, BoE, ICO, UK Parliament, etc.) with titles, issuers, URLs and scopes.  
- Updated `docs/_layouts/mitigation.html` and `docs/_layouts/risk.html` to include a `reference-card` for the new `uk-regulations` dataset so UK references appear on mitigation and risk pages.  
- Updated several risk markdown files (including `ri-1`, `ri-2`, `ri-16`, `ri-17`, `ri-18`, `ri-19`, `ri-20`, `ri-22`) to add `uk-regulations_references` entries that map specific UK rules and guidance to each risk.  
- Included inline comments in the YAML indicating verification date and the intended scope (curated for the AI Governance Framework risk catalogue).

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a31390bd9008328bb431c923768996d)